### PR TITLE
Implement comprehensive crossword word validation

### DIFF
--- a/utils/llm_generator.py
+++ b/utils/llm_generator.py
@@ -13,7 +13,7 @@ from langchain_core.pydantic_v1 import BaseModel, Field, ValidationError
 from langchain_core.prompts import ChatPromptTemplate
 from langchain_openai import ChatOpenAI
 
-from utils.validators import validate_word_clues
+from utils.validators import validate_word_list
 
 logger = logging.getLogger(__name__)
 
@@ -160,7 +160,7 @@ def generate_clues(theme: str, language: str) -> list[WordClue]:
             raw_content = response.content if hasattr(response, "content") else str(response)
             parsed = _parse_response(raw_content)
             normalised = _normalise_payload(parsed.clues)
-            validated = validate_word_clues(normalised, language)
+            validated = validate_word_list(language, normalised)
 
             if len(validated) >= 60:
                 logger.info("Generated %s validated clues", len(validated))

--- a/utils/validators.py
+++ b/utils/validators.py
@@ -4,18 +4,79 @@ from __future__ import annotations
 
 import logging
 import re
-from dataclasses import replace
-from typing import Sequence
+import unicodedata
+from dataclasses import dataclass, replace
+from typing import Iterable, Sequence, TYPE_CHECKING
 
 logger = logging.getLogger(__name__)
 
+if TYPE_CHECKING:  # pragma: no cover - used only for typing
+    from utils.llm_generator import WordClue
+
+__all__ = [
+    "CharacterValidationError",
+    "DuplicateWordError",
+    "LengthValidationError",
+    "WordValidationError",
+    "WordValidationIssue",
+    "get_last_validation_issues",
+    "validate_word_clues",
+    "validate_word_list",
+]
+
+
+class WordValidationError(Exception):
+    """Base class for validation errors describing why a word is rejected."""
+
+    code = "invalid"
+
+    def __init__(self, message: str, *, code: str | None = None) -> None:
+        super().__init__(message)
+        if code is not None:
+            self.code = code
+
+
+class CharacterValidationError(WordValidationError):
+    """Raised when a word contains unsupported characters."""
+
+    code = "characters"
+
+
+class LengthValidationError(WordValidationError):
+    """Raised when a word is shorter or longer than allowed."""
+
+    code = "length"
+
+
+class DuplicateWordError(WordValidationError):
+    """Raised when the word duplicates an already accepted entry."""
+
+    code = "duplicate"
+
+
+@dataclass(slots=True)
+class WordValidationIssue:
+    """Represents a rejected word alongside the reason."""
+
+    clue: "WordClue"
+    word: str
+    canonical_word: str
+    error: WordValidationError
+
 
 _LANGUAGE_PATTERNS: dict[str, re.Pattern[str]] = {
-    "en": re.compile(r"^[A-Z]{3,12}$"),
-    "ru": re.compile(r"^[А-ЯЁ]{3,12}$"),
-    "it": re.compile(r"^[A-ZÀÈÉÌÒÙ]{3,12}$"),
-    "es": re.compile(r"^[A-ZÁÉÍÑÓÚÜ]{3,12}$"),
+    "en": re.compile(r"^[A-Z]+$"),
+    "ru": re.compile(r"^[А-ЯЁ]+$"),
+    "it": re.compile(r"^[A-ZÀÈÉÌÒÙ]+$"),
+    "es": re.compile(r"^[A-ZÁÉÍÑÓÚÜ]+$"),
 }
+
+_GENERIC_LETTERS = re.compile(r"^[^\W\d_]+$", re.UNICODE)
+
+_MIN_WORD_LENGTH = 3
+_MAX_WORD_LENGTH = 12
+
+_LAST_VALIDATION_ISSUES: list[WordValidationIssue] = []
 
 
 def _normalise_language(language: str) -> str:
@@ -28,13 +89,65 @@ def _pattern_for_language(language: str) -> re.Pattern[str]:
         return _LANGUAGE_PATTERNS[normalised]
 
     logger.debug("No dedicated alphabet pattern for %s, using generic unicode letters", language)
-    return re.compile(r"^[^\W\d_]{3,12}$", re.UNICODE)
+    return _GENERIC_LETTERS
 
 
-def validate_word_clues(
-    word_clues: Sequence["WordClue"], language: str, *, deduplicate: bool = True
+def _strip_accents(text: str) -> str:
+    decomposed = unicodedata.normalize("NFD", text)
+    return "".join(ch for ch in decomposed if unicodedata.category(ch) != "Mn")
+
+
+def _canonicalise_word(word: str) -> str:
+    """Normalise a word for duplicate checks (case, accents, apostrophes, ё/е)."""
+
+    cleaned = _strip_accents(word)
+    cleaned = cleaned.replace("’", "'").replace("`", "'").replace("´", "'")
+    cleaned = cleaned.replace("Ё", "Е").replace("ё", "е")
+    cleaned = cleaned.replace("'", "")
+    return cleaned.upper()
+
+
+def _prepare_word(word: str) -> str:
+    return unicodedata.normalize("NFC", word or "").strip()
+
+
+def _validate_length(word: str) -> None:
+    if not (_MIN_WORD_LENGTH <= len(word) <= _MAX_WORD_LENGTH):
+        raise LengthValidationError(
+            f"Word length must be between {_MIN_WORD_LENGTH} and {_MAX_WORD_LENGTH} characters",
+        )
+
+
+def _validate_characters(word: str, pattern: re.Pattern[str]) -> None:
+    if not pattern.fullmatch(word):
+        raise CharacterValidationError(
+            "Word must consist only of alphabetic characters for the selected language",
+        )
+
+
+def _normalise_for_output(word: str) -> str:
+    return unicodedata.normalize("NFC", word).upper()
+
+
+def get_last_validation_issues() -> list[WordValidationIssue]:
+    """Return the list of issues collected during the last validation call."""
+
+    return list(_LAST_VALIDATION_ISSUES)
+
+
+def validate_word_list(
+    language: str, words: Iterable["WordClue"], *, deduplicate: bool = True
 ) -> list["WordClue"]:
-    """Validate that generated clues meet the crossword requirements."""
+    """Validate crossword entries and return only the acceptable ones.
+
+    Args:
+        language: Target crossword language (determines alphabet rules).
+        words: Iterable of :class:`WordClue` instances to validate.
+        deduplicate: When ``True`` (default) repeated words are rejected.
+
+    The function records detailed information about every rejected word and stores it
+    in :func:`get_last_validation_issues` for diagnostic purposes.
+    """
 
     try:
         from utils.llm_generator import WordClue  # local import to avoid circular dependency
@@ -43,20 +156,41 @@ def validate_word_clues(
         raise
 
     pattern = _pattern_for_language(language)
-    valid_clues: list[WordClue] = []
+    accepted: list[WordClue] = []
+    issues: list[WordValidationIssue] = []
     seen: set[str] = set()
 
-    for clue in word_clues:
-        word = clue.word
-        if not pattern.match(word):
-            logger.debug("Skipping word %s – does not match language constraints", word)
+    for clue in words:
+        raw_word = _prepare_word(clue.word)
+        canonical_word = _canonicalise_word(raw_word)
+
+        try:
+            _validate_length(raw_word)
+            _validate_characters(_normalise_for_output(raw_word), pattern)
+            if deduplicate and canonical_word in seen:
+                raise DuplicateWordError("Word duplicates a previously accepted entry")
+        except WordValidationError as exc:
+            issue = WordValidationIssue(clue=clue, word=raw_word, canonical_word=canonical_word, error=exc)
+            issues.append(issue)
+            logger.debug("Rejected word %r (%s): %s", raw_word, exc.code, exc)
             continue
 
-        if deduplicate and word in seen:
-            logger.debug("Skipping duplicated word %s", word)
-            continue
+        if deduplicate:
+            seen.add(canonical_word)
+        accepted.append(replace(clue, word=_normalise_for_output(raw_word)))
 
-        seen.add(word)
-        valid_clues.append(replace(clue))
+    _LAST_VALIDATION_ISSUES.clear()
+    _LAST_VALIDATION_ISSUES.extend(issues)
 
-    return valid_clues
+    if issues:
+        logger.debug("Validation rejected %s words for language %s", len(issues), language)
+
+    return accepted
+
+
+def validate_word_clues(
+    word_clues: Sequence["WordClue"], language: str, *, deduplicate: bool = True
+) -> list["WordClue"]:
+    """Backward compatible wrapper around :func:`validate_word_list`."""
+
+    return validate_word_list(language, word_clues, deduplicate=deduplicate)


### PR DESCRIPTION
## Summary
- add dedicated character and length validation utilities with canonical normalisation, duplicate detection and debug logging
- surface custom validation errors/issues plus `validate_word_list` for downstream crossword generation
- update the LLM clue generator to adopt the new validation entrypoint

## Testing
- python -m compileall utils/validators.py utils/llm_generator.py

------
https://chatgpt.com/codex/tasks/task_e_68cd9808194483268b768352cd42be1b