### PR TITLE
Implement Telegram gameplay handlers

### DIFF
--- a/app.py
+++ b/app.py
@@ -5,22 +5,48 @@ from __future__ import annotations
 import asyncio
 import logging
 import os
+import time
+from uuid import uuid4
 from contextlib import suppress
 from dataclasses import dataclass
-from typing import Optional
+from typing import Iterable, Optional, Sequence
 
 from fastapi import Depends, FastAPI, HTTPException, Request
 from fastapi.responses import JSONResponse
-from telegram import Update
-from telegram.ext import Application
+from telegram import Update, constants
+from telegram.constants import ChatType
+from telegram.ext import (
+    Application,
+    CallbackContext,
+    CommandHandler,
+    ConversationHandler,
+    ContextTypes,
+    MessageHandler,
+    filters,
+)
 from telegram.request import HTTPXRequest
 
 from utils.storage import (
     STATE_CLEANUP_INTERVAL,
     GameState,
+    load_puzzle,
     load_all_states,
+    load_state,
     prune_expired_states,
+    save_puzzle,
+    save_state,
 )
+from utils.crossword import (
+    Direction,
+    Puzzle,
+    Slot,
+    fill_puzzle_with_words,
+    puzzle_from_dict,
+    puzzle_to_dict,
+)
+from utils.llm_generator import WordClue, generate_clues
+from utils.render import render_puzzle
+from utils.validators import WordValidationError, validate_word_list
 
 # ---------------------------------------------------------------------------
 # Logging configuration
@@ -136,6 +162,626 @@ def register_webhook_route(path: str) -> None:
 
 
 # ---------------------------------------------------------------------------
+# Game helpers and conversation configuration
+# ---------------------------------------------------------------------------
+
+
+LANGUAGE_STATE, THEME_STATE = range(2)
+
+REMINDER_DELAY_SECONDS = 10 * 60
+
+DEFAULT_PUZZLE_TEMPLATE = (
+    "##.#...#.##",
+    "#..##.##..#",
+    "..#..#..#..",
+    ".#...#...#.",
+    "..##...##..",
+    "###.....###",
+    "..##...##..",
+    ".#...#...#.",
+    "..#..#..#..",
+    "#..##.##..#",
+    "##.#...#.##",
+)
+
+
+def _parse_block_template(template: Sequence[str]) -> set[tuple[int, int]]:
+    positions: set[tuple[int, int]] = set()
+    for row, row_value in enumerate(template):
+        for col, char in enumerate(row_value):
+            if char == "#":
+                positions.add((row, col))
+    return positions
+
+
+DEFAULT_BLOCK_POSITIONS = _parse_block_template(DEFAULT_PUZZLE_TEMPLATE)
+
+
+def _normalise_thread_id(update: Update) -> int:
+    message = update.effective_message
+    thread_id = 0
+    if message is not None and message.message_thread_id is not None:
+        thread_id = message.message_thread_id
+    logger.debug(
+        "Normalised thread id for chat %s: %s",
+        update.effective_chat.id if update.effective_chat else "<unknown>",
+        thread_id,
+    )
+    return thread_id
+
+
+def _coord_key(row: int, col: int) -> str:
+    return f"{row},{col}"
+
+
+def _normalise_slot_id(slot_id: str) -> str:
+    return slot_id.strip().upper()
+
+
+def _find_slot(puzzle: Puzzle, slot_id: str) -> Optional[Slot]:
+    normalised = _normalise_slot_id(slot_id)
+    for slot in puzzle.slots:
+        if slot.slot_id.upper() == normalised:
+            return slot
+    return None
+
+
+def _canonical_answer(word: str, language: str) -> str:
+    transformed = (word or "").strip().upper()
+    if language.lower() == "ru":
+        transformed = transformed.replace("Ё", "Е")
+    return transformed
+
+
+def _ensure_hint_set(game_state: GameState) -> set[str]:
+    if game_state.hinted_cells is None:
+        game_state.hinted_cells = set()
+    return game_state.hinted_cells
+
+
+def _store_state(game_state: GameState) -> None:
+    state.active_states[game_state.chat_id] = game_state
+    save_state(game_state)
+    logger.debug("Game state for chat %s persisted", game_state.chat_id)
+
+
+def _load_state_for_chat(chat_id: int) -> Optional[GameState]:
+    if chat_id in state.active_states:
+        return state.active_states[chat_id]
+    restored = load_state(chat_id)
+    if restored is None:
+        return None
+    state.active_states[chat_id] = restored
+    logger.debug("Restored state for chat %s from disk during command handling", chat_id)
+    return restored
+
+
+def _load_puzzle_for_state(game_state: GameState) -> Optional[Puzzle]:
+    payload = load_puzzle(game_state.puzzle_id)
+    if payload is None:
+        logger.error("Puzzle %s referenced by chat %s is missing", game_state.puzzle_id, game_state.chat_id)
+        return None
+    return puzzle_from_dict(dict(payload))
+
+
+def _format_clue_section(slots: Iterable[Slot]) -> str:
+    lines = []
+    for slot in slots:
+        clue_text = slot.clue or "(нет подсказки)"
+        lines.append(f"{slot.slot_id} ({slot.length}): {clue_text}")
+    return "\n".join(lines) if lines else "(подсказок нет)"
+
+
+def _format_clues_message(puzzle: Puzzle) -> str:
+    across = [slot for slot in puzzle.slots if slot.direction is Direction.ACROSS]
+    down = [slot for slot in puzzle.slots if slot.direction is Direction.DOWN]
+    across_text = _format_clue_section(across)
+    down_text = _format_clue_section(down)
+    return f"Across:\n{across_text}\n\nDown:\n{down_text}"
+
+
+def _ensure_private_chat(update: Update) -> bool:
+    chat = update.effective_chat
+    is_private = bool(chat and chat.type == ChatType.PRIVATE)
+    if not is_private and update.effective_message:
+        logger.debug("Rejected command in non-private chat %s", chat.id if chat else "<unknown>")
+    return is_private
+
+
+async def _reject_group_chat(update: Update) -> bool:
+    if _ensure_private_chat(update):
+        return True
+    if update.effective_message:
+        await update.effective_message.reply_text(
+            "Пожалуйста, используйте этого бота в личном чате."
+        )
+    return False
+
+
+def _apply_answer_to_state(game_state: GameState, slot: Slot, answer: str) -> None:
+    logger.debug("Applying answer for slot %s in chat %s", slot.slot_id, game_state.chat_id)
+    keys: list[str] = []
+    for index, (row, col) in enumerate(slot.coordinates()):
+        key = _coord_key(row, col)
+        keys.append(key)
+        if index < len(answer):
+            game_state.filled_cells[key] = answer[index]
+    hint_set = _ensure_hint_set(game_state)
+    for key in keys:
+        hint_set.discard(key)
+    game_state.solved_slots.add(slot.slot_id)
+    game_state.last_update = time.time()
+    _store_state(game_state)
+
+
+def _reveal_letter(game_state: GameState, slot: Slot, answer: str) -> Optional[tuple[int, str]]:
+    hint_set = _ensure_hint_set(game_state)
+    for index, (row, col) in enumerate(slot.coordinates()):
+        key = _coord_key(row, col)
+        if key in game_state.filled_cells:
+            continue
+        if index >= len(answer):
+            break
+        letter = answer[index]
+        game_state.filled_cells[key] = letter
+        hint_set.add(key)
+        game_state.hints_used += 1
+        game_state.last_update = time.time()
+        _store_state(game_state)
+        return index, letter
+    return None
+
+
+def _all_slots_solved(puzzle: Puzzle, game_state: GameState) -> bool:
+    solved = set(game_state.solved_slots)
+    return all(slot.slot_id in solved for slot in puzzle.slots if slot.answer)
+
+
+def _solve_remaining_slots(game_state: GameState, puzzle: Puzzle) -> list[tuple[str, str]]:
+    solved_now: list[tuple[str, str]] = []
+    hint_set = _ensure_hint_set(game_state)
+    for slot in puzzle.slots:
+        if not slot.answer:
+            continue
+        if slot.slot_id in game_state.solved_slots:
+            continue
+        answer = slot.answer
+        for index, (row, col) in enumerate(slot.coordinates()):
+            if index >= len(answer):
+                break
+            key = _coord_key(row, col)
+            game_state.filled_cells[key] = answer[index]
+            hint_set.discard(key)
+        game_state.solved_slots.add(slot.slot_id)
+        solved_now.append((slot.slot_id, answer))
+    if solved_now:
+        game_state.last_update = time.time()
+        _store_state(game_state)
+    return solved_now
+
+
+def _cancel_reminder(context: ContextTypes.DEFAULT_TYPE) -> None:
+    job = context.chat_data.pop("reminder_job", None)
+    if job is not None:
+        logger.debug("Cancelling existing reminder job %s", job.name)
+        job.schedule_removal()
+
+
+async def _reminder_job(context: CallbackContext) -> None:
+    job = context.job
+    if job is None:
+        return
+    chat_id = job.chat_id
+    logger.debug("Sending reminder for chat %s", chat_id)
+    try:
+        await context.bot.send_message(
+            chat_id=chat_id,
+            text="Не забывайте про /hint, если нужна подсказка!",
+        )
+    except Exception:  # noqa: BLE001
+        logger.exception("Failed to deliver reminder message to chat %s", chat_id)
+
+
+def _assign_clues_to_slots(puzzle: Puzzle, clues: Sequence[WordClue]) -> None:
+    language = puzzle.language
+    clue_map: dict[str, str] = {}
+    for clue in clues:
+        clue_map[_canonical_answer(clue.word, language)] = clue.clue
+    for slot in puzzle.slots:
+        if not slot.answer:
+            continue
+        canonical = _canonical_answer(slot.answer, language)
+        slot.clue = clue_map.get(canonical, f"Слово из {slot.length} букв")
+
+
+def _generate_puzzle(chat_id: int, language: str, theme: str) -> tuple[Puzzle, GameState]:
+    logger.debug(
+        "Starting puzzle generation for chat %s (language=%s, theme=%s)",
+        chat_id,
+        language,
+        theme,
+    )
+    clues = generate_clues(theme=theme, language=language)
+    logger.debug("Generated %s raw clues from LLM", len(clues))
+    validated_clues = validate_word_list(language, clues, deduplicate=True)
+    if not validated_clues:
+        raise RuntimeError("Не удалось подобрать ни одного подходящего слова")
+
+    max_attempt_words = min(len(validated_clues), 80)
+    min_attempt_words = max(10, min(30, max_attempt_words))
+
+    rows = len(DEFAULT_PUZZLE_TEMPLATE)
+    cols = len(DEFAULT_PUZZLE_TEMPLATE[0]) if rows else 11
+
+    for limit in range(max_attempt_words, min_attempt_words - 1, -1):
+        candidate_words = [clue.word for clue in validated_clues[:limit]]
+        puzzle_id = uuid4().hex
+        puzzle = Puzzle.from_size(
+            puzzle_id=puzzle_id,
+            theme=theme,
+            language=language,
+            rows=rows,
+            cols=cols,
+            block_positions=DEFAULT_BLOCK_POSITIONS,
+        )
+        if fill_puzzle_with_words(puzzle, candidate_words):
+            _assign_clues_to_slots(puzzle, validated_clues)
+            save_puzzle(puzzle.id, puzzle_to_dict(puzzle))
+            now = time.time()
+            game_state = GameState(
+                chat_id=chat_id,
+                puzzle_id=puzzle.id,
+                filled_cells={},
+                solved_slots=set(),
+                score=0,
+                hints_used=0,
+                started_at=now,
+                last_update=now,
+                hinted_cells=set(),
+            )
+            _store_state(game_state)
+            logger.info("Generated puzzle %s for chat %s", puzzle.id, chat_id)
+            return puzzle, game_state
+        logger.debug("Attempt with %s words failed to fill puzzle", limit)
+
+    raise RuntimeError("Не удалось сформировать кроссворд из сгенерированных слов")
+
+
+# ---------------------------------------------------------------------------
+# Telegram command handlers
+# ---------------------------------------------------------------------------
+
+
+async def start_new_game(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
+    _normalise_thread_id(update)
+    if not await _reject_group_chat(update):
+        return ConversationHandler.END
+    logger.debug("Chat %s initiated /new", update.effective_chat.id if update.effective_chat else "<unknown>")
+    context.user_data["new_game_language"] = None
+    if update.effective_message:
+        await update.effective_message.reply_text(
+            "Выберите язык кроссворда (например: ru, en, it, es).",
+        )
+    return LANGUAGE_STATE
+
+
+async def handle_language(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
+    _normalise_thread_id(update)
+    if not await _reject_group_chat(update):
+        return ConversationHandler.END
+    message = update.effective_message
+    if message is None or not message.text:
+        return LANGUAGE_STATE
+    language = message.text.strip().lower()
+    if not language or not language.isalpha():
+        await message.reply_text("Пожалуйста, введите язык одним словом, например ru.")
+        return LANGUAGE_STATE
+    logger.debug("Chat %s selected language %s", update.effective_chat.id if update.effective_chat else "<unknown>", language)
+    context.user_data["new_game_language"] = language
+    await message.reply_text("Отлично! Теперь укажите тему кроссворда.")
+    return THEME_STATE
+
+
+async def handle_theme(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
+    _normalise_thread_id(update)
+    if not await _reject_group_chat(update):
+        return ConversationHandler.END
+    message = update.effective_message
+    if message is None or not message.text:
+        return THEME_STATE
+    language = context.user_data.get("new_game_language")
+    if not language:
+        await message.reply_text("Сначала выберите язык через команду /new.")
+        return ConversationHandler.END
+    theme = message.text.strip()
+    if not theme:
+        await message.reply_text("Введите тему, например: Древний Рим.")
+        return THEME_STATE
+
+    chat = update.effective_chat
+    if chat is None:
+        return ConversationHandler.END
+
+    logger.debug("Chat %s requested theme '%s'", chat.id, theme)
+    await message.reply_text("Готовлю кроссворд, это может занять немного времени...")
+    loop = asyncio.get_running_loop()
+    try:
+        puzzle, game_state = await loop.run_in_executor(
+            None, _generate_puzzle, chat.id, language, theme
+        )
+    except Exception as exc:  # noqa: BLE001
+        logger.exception("Failed to generate puzzle for chat %s", chat.id)
+        await message.reply_text(f"Не удалось создать кроссворд: {exc}")
+        context.user_data.pop("new_game_language", None)
+        return ConversationHandler.END
+
+    context.user_data.pop("new_game_language", None)
+    _cancel_reminder(context)
+
+    image_path = render_puzzle(puzzle, game_state)
+    await context.bot.send_chat_action(chat_id=chat.id, action=constants.ChatAction.UPLOAD_PHOTO)
+    with open(image_path, "rb") as photo:
+        await message.reply_photo(
+            photo=photo,
+            caption=(
+                f"Кроссворд готов!\nЯзык: {puzzle.language.upper()}\nТема: {puzzle.theme}"
+            ),
+        )
+
+    await message.reply_text(_format_clues_message(puzzle))
+
+    if context.job_queue:
+        job = context.job_queue.run_once(
+            _reminder_job,
+            REMINDER_DELAY_SECONDS,
+            chat_id=chat.id,
+            name=f"hint-reminder-{chat.id}",
+        )
+        context.chat_data["reminder_job"] = job
+
+    return ConversationHandler.END
+
+
+async def cancel_new_game(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
+    _normalise_thread_id(update)
+    context.user_data.pop("new_game_language", None)
+    if update.effective_message:
+        await update.effective_message.reply_text("Создание кроссворда отменено.")
+    return ConversationHandler.END
+
+
+async def send_clues(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    _normalise_thread_id(update)
+    if not await _reject_group_chat(update):
+        return
+    chat = update.effective_chat
+    message = update.effective_message
+    if chat is None or message is None:
+        return
+    logger.debug("Chat %s requested /clues", chat.id)
+    game_state = _load_state_for_chat(chat.id)
+    if not game_state:
+        await message.reply_text("Нет активной игры. Используйте /new для начала.")
+        return
+    puzzle = _load_puzzle_for_state(game_state)
+    if puzzle is None:
+        await message.reply_text("Не удалось загрузить кроссворд. Попробуйте начать новую игру.")
+        return
+    await message.reply_text(_format_clues_message(puzzle))
+
+
+async def send_state_image(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    _normalise_thread_id(update)
+    if not await _reject_group_chat(update):
+        return
+    chat = update.effective_chat
+    message = update.effective_message
+    if chat is None or message is None:
+        return
+    logger.debug("Chat %s requested /state", chat.id)
+    game_state = _load_state_for_chat(chat.id)
+    if not game_state:
+        await message.reply_text("Нет активного кроссворда. Используйте /new.")
+        return
+    puzzle = _load_puzzle_for_state(game_state)
+    if puzzle is None:
+        await message.reply_text("Кроссворд не найден. Попробуйте начать новую игру.")
+        return
+    image_path = render_puzzle(puzzle, game_state)
+    await context.bot.send_chat_action(chat_id=chat.id, action=constants.ChatAction.UPLOAD_PHOTO)
+    with open(image_path, "rb") as photo:
+        await message.reply_photo(photo=photo)
+
+
+async def answer_command(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    _normalise_thread_id(update)
+    if not await _reject_group_chat(update):
+        return
+    chat = update.effective_chat
+    message = update.effective_message
+    if chat is None or message is None:
+        return
+    if not context.args or len(context.args) < 2:
+        await message.reply_text("Использование: /answer <слот> <слово>")
+        return
+
+    slot_id = context.args[0]
+    logger.debug("Chat %s answering slot %s", chat.id, slot_id)
+    raw_answer = " ".join(context.args[1:])
+
+    game_state = _load_state_for_chat(chat.id)
+    if not game_state:
+        await message.reply_text("Нет активного кроссворда. Используйте /new.")
+        return
+    puzzle = _load_puzzle_for_state(game_state)
+    if puzzle is None:
+        await message.reply_text("Не удалось загрузить кроссворд. Попробуйте начать заново.")
+        return
+    slot = _find_slot(puzzle, slot_id)
+    if slot is None:
+        await message.reply_text(f"Слот {slot_id} не найден.")
+        return
+    if slot.slot_id in game_state.solved_slots:
+        await message.reply_text("Этот слот уже решён.")
+        return
+    if not slot.answer:
+        await message.reply_text("Для этого слота не задан ответ.")
+        return
+
+    try:
+        validated = validate_word_list(
+            puzzle.language,
+            [WordClue(word=raw_answer, clue="")],
+            deduplicate=False,
+        )
+    except WordValidationError as exc:
+        logger.debug("Validation error for chat %s: %s", chat.id, exc)
+        await message.reply_text(f"Слово не прошло проверку: {exc}")
+        return
+    except Exception as exc:  # noqa: BLE001
+        logger.exception("Unexpected error validating answer for chat %s", chat.id)
+        await message.reply_text(f"Не удалось проверить слово: {exc}")
+        return
+
+    if not validated:
+        await message.reply_text("Слово не соответствует правилам языка.")
+        return
+
+    candidate = validated[0].word
+    if _canonical_answer(candidate, puzzle.language) != _canonical_answer(slot.answer, puzzle.language):
+        await message.reply_text("Ответ неверный, попробуйте ещё раз.")
+        return
+
+    game_state.score += slot.length
+    _apply_answer_to_state(game_state, slot, candidate)
+
+    image_path = render_puzzle(puzzle, game_state)
+    await context.bot.send_chat_action(chat_id=chat.id, action=constants.ChatAction.UPLOAD_PHOTO)
+    with open(image_path, "rb") as photo:
+        await message.reply_photo(photo=photo, caption=f"Верно! {slot.slot_id}")
+
+    if _all_slots_solved(puzzle, game_state):
+        _cancel_reminder(context)
+        await message.reply_text("Поздравляем! Все слова разгаданы.")
+
+
+async def hint_command(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    _normalise_thread_id(update)
+    if not await _reject_group_chat(update):
+        return
+    chat = update.effective_chat
+    message = update.effective_message
+    if chat is None or message is None:
+        return
+    logger.debug("Chat %s requested /hint", chat.id)
+
+    game_state = _load_state_for_chat(chat.id)
+    if not game_state:
+        await message.reply_text("Нет активной игры. Используйте /new.")
+        return
+    puzzle = _load_puzzle_for_state(game_state)
+    if puzzle is None:
+        await message.reply_text("Не удалось загрузить кроссворд.")
+        return
+
+    slot: Optional[Slot] = None
+    if context.args:
+        slot = _find_slot(puzzle, context.args[0])
+        if slot is None:
+            await message.reply_text(f"Слот {context.args[0]} не найден.")
+            return
+    else:
+        for candidate in puzzle.slots:
+            if candidate.slot_id in game_state.solved_slots:
+                continue
+            if not candidate.answer:
+                continue
+            slot = candidate
+            break
+        if slot is None:
+            await message.reply_text("Нет слотов для подсказки.")
+            return
+
+    if not slot.answer:
+        await message.reply_text("Для этого слота нет ответа.")
+        return
+
+    result = _reveal_letter(game_state, slot, slot.answer)
+    if result is None:
+        game_state.hints_used += 1
+        game_state.last_update = time.time()
+        _store_state(game_state)
+        reply_text = (
+            f"Все буквы в {slot.slot_id} уже открыты. Подсказка: {slot.clue or 'нет'}"
+        )
+    else:
+        position, letter = result
+        reply_text = (
+            f"Открыта буква №{position + 1} в {slot.slot_id}: {letter}\n"
+            f"Подсказка: {slot.clue or 'нет'}"
+        )
+
+    image_path = render_puzzle(puzzle, game_state)
+    await context.bot.send_chat_action(chat_id=chat.id, action=constants.ChatAction.UPLOAD_PHOTO)
+    with open(image_path, "rb") as photo:
+        await message.reply_photo(photo=photo, caption=reply_text)
+
+
+async def solve_command(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    _normalise_thread_id(update)
+    if not await _reject_group_chat(update):
+        return
+    chat = update.effective_chat
+    message = update.effective_message
+    if chat is None or message is None:
+        return
+    logger.debug("Chat %s requested /solve", chat.id)
+
+    game_state = _load_state_for_chat(chat.id)
+    if not game_state:
+        await message.reply_text("Нет активной игры.")
+        return
+    puzzle = _load_puzzle_for_state(game_state)
+    if puzzle is None:
+        await message.reply_text("Кроссворд не найден. Запустите /new.")
+        return
+
+    solved_now = _solve_remaining_slots(game_state, puzzle)
+    if not solved_now:
+        await message.reply_text("Все ответы уже открыты.")
+        return
+
+    _cancel_reminder(context)
+
+    image_path = render_puzzle(puzzle, game_state)
+    await context.bot.send_chat_action(chat_id=chat.id, action=constants.ChatAction.UPLOAD_PHOTO)
+    with open(image_path, "rb") as photo:
+        await message.reply_photo(photo=photo, caption="Кроссворд раскрыт полностью.")
+
+    solved_lines = "\n".join(f"{slot_id}: {answer}" for slot_id, answer in solved_now)
+    await message.reply_text(f"Оставшиеся ответы:\n{solved_lines}")
+
+
+def configure_telegram_handlers(telegram_application: Application) -> None:
+    conversation = ConversationHandler(
+        entry_points=[CommandHandler("new", start_new_game)],
+        states={
+            LANGUAGE_STATE: [MessageHandler(filters.TEXT & ~filters.COMMAND, handle_language)],
+            THEME_STATE: [MessageHandler(filters.TEXT & ~filters.COMMAND, handle_theme)],
+        },
+        fallbacks=[CommandHandler("cancel", cancel_new_game)],
+        name="new_game_conversation",
+    )
+    telegram_application.add_handler(conversation)
+    telegram_application.add_handler(CommandHandler("clues", send_clues))
+    telegram_application.add_handler(CommandHandler("state", send_state_image))
+    telegram_application.add_handler(CommandHandler("answer", answer_command))
+    telegram_application.add_handler(CommandHandler(["hint", "open"], hint_command))
+    telegram_application.add_handler(CommandHandler("solve", solve_command))
+    telegram_application.add_handler(CommandHandler("cancel", cancel_new_game))
+
+
+# ---------------------------------------------------------------------------
 # Webhook monitoring
 # ---------------------------------------------------------------------------
 
@@ -215,6 +861,8 @@ async def on_startup() -> None:
         .updater(None)
         .build()
     )
+
+    configure_telegram_handlers(telegram_application)
 
     await telegram_application.initialize()
     logger.info("Telegram application initialized")

--- a/utils/storage.py
+++ b/utils/storage.py
@@ -36,6 +36,7 @@ class GameState:
     hints_used: int
     started_at: float
     last_update: float
+    hinted_cells: set[str] | None = None
 
     def to_dict(self) -> Dict[str, Any]:
         """Serialize the state into a JSON-compatible dictionary."""
@@ -49,6 +50,7 @@ class GameState:
             "hints_used": self.hints_used,
             "started_at": self.started_at,
             "last_update": self.last_update,
+            "hinted_cells": sorted(self.hinted_cells or ()),
         }
 
     @classmethod
@@ -71,6 +73,7 @@ class GameState:
             hints_used=int(payload.get("hints_used", 0)),
             started_at=float(payload.get("started_at", time.time())),
             last_update=float(payload.get("last_update", time.time())),
+            hinted_cells={str(item) for item in payload.get("hinted_cells", [])},
         )
 
 


### PR DESCRIPTION
## Summary
- add crossword generation workflow with conversation handler for /new
- implement gameplay commands for clues, answers, hints, state rendering and solving
- persist and restore hint data within stored game state and schedule reminder jobs

## Testing
- python -m compileall app.py utils

------
https://chatgpt.com/codex/tasks/task_e_68cdaadf74308326a55624c653e1332b