### PR TITLE
Use uvicorn standard extras

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 python-telegram-bot>=20.6
 fastapi>=0.110
-uvicorn>=0.30
+uvicorn[standard]>=0.30
 langchain>=0.2
 openai>=1.40
 pillow>=10.0


### PR DESCRIPTION
## Summary
- request the standard extra when installing uvicorn so optional runtime dependencies are pulled in

## Testing
- `pip install -r requirements.txt` *(fails: external network proxy returned 403 when downloading packages)*

------
https://chatgpt.com/codex/tasks/task_e_68ce2a4ae9908326bc10576a46dfe4b7