### PR TITLE
Fix LangChain OutputParserException import for deployment

### DIFF
--- a/utils/llm_generator.py
+++ b/utils/llm_generator.py
@@ -7,7 +7,8 @@ import os
 from dataclasses import dataclass
 from typing import Iterable
 
-from langchain_core.output_parsers import OutputParserException, PydanticOutputParser
+from langchain_core.exceptions import OutputParserException
+from langchain_core.output_parsers import PydanticOutputParser
 from langchain_core.pydantic_v1 import BaseModel, Field, ValidationError
 from langchain_core.prompts import ChatPromptTemplate
 from langchain_openai import ChatOpenAI


### PR DESCRIPTION
## Summary
- update the LangChain exception import to use the new module path

## Testing
- python -m compileall utils/llm_generator.py

------
https://chatgpt.com/codex/tasks/task_e_68ce3d4872408326bd34b09c0e34673e