### PR TITLE
Expand validator max length to 15

### DIFF
--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -1,0 +1,55 @@
+import sys
+import types
+import unittest
+from dataclasses import dataclass
+
+try:  # pragma: no cover - exercised implicitly when dependencies are present
+    from utils.llm_generator import WordClue
+except Exception:  # pragma: no cover - fallback when optional deps are missing
+    fake_llm_generator = types.ModuleType("utils.llm_generator")
+
+    @dataclass(slots=True)
+    class WordClue:  # type: ignore[redefinition]
+        word: str
+        clue: str
+        direction_preference: str | None = None
+
+    fake_llm_generator.WordClue = WordClue
+    sys.modules["utils.llm_generator"] = fake_llm_generator
+
+from utils.validators import (
+    LengthValidationError,
+    get_last_validation_issues,
+    validate_word_list,
+)
+
+
+class ValidatorMaxLengthTests(unittest.TestCase):
+    def test_accepts_fifteen_letter_words_for_supported_languages(self) -> None:
+        cases = {
+            "en": "abcdefghijklmno",
+            "ru": "о" * 15,
+            "it": "àèéìòùabcdefghi",
+            "es": "áéíóúüñabcdeñop",
+        }
+
+        for language, word in cases.items():
+            with self.subTest(language=language):
+                accepted = validate_word_list(language, [WordClue(word=word, clue="test clue")])
+                self.assertEqual(1, len(accepted))
+                self.assertEqual(word.upper(), accepted[0].word)
+                self.assertEqual([], get_last_validation_issues())
+
+    def test_rejects_words_longer_than_fifteen_characters(self) -> None:
+        word = "abcdefghijklmnop"  # 16 characters
+        accepted = validate_word_list("en", [WordClue(word=word, clue="test clue")])
+
+        self.assertEqual([], accepted)
+        issues = get_last_validation_issues()
+        self.assertEqual(1, len(issues))
+        self.assertIsInstance(issues[0].error, LengthValidationError)
+        self.assertIn("3 and 15", str(issues[0].error))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/utils/llm_generator.py
+++ b/utils/llm_generator.py
@@ -56,7 +56,7 @@ _PROMPT = ChatPromptTemplate.from_messages(
             "Theme: {theme}\n"
             "Language: {language}\n"
             "Generate at least 60 unique single-word crossword answers that fit the theme. "
-            "Each answer must be between 3 and 12 characters long, consist only of letters of the target language, "
+            "Each answer must be between 3 and 15 characters long, consist only of letters of the target language, "
             "and must not contain spaces, hyphens or digits. Provide a concise clue for every word and an optional "
             "direction preference (across, down, any).",
         ),

--- a/utils/validators.py
+++ b/utils/validators.py
@@ -75,7 +75,7 @@ _LANGUAGE_PATTERNS: dict[str, re.Pattern[str]] = {
 _GENERIC_LETTERS = re.compile(r"^[^\W\d_]+$", re.UNICODE)
 
 _MIN_WORD_LENGTH = 3
-_MAX_WORD_LENGTH = 12
+_MAX_WORD_LENGTH = 15
 
 _LAST_VALIDATION_ISSUES: list[WordValidationIssue] = []
 


### PR DESCRIPTION
## Summary
- raise the crossword validator maximum word length to fifteen characters
- update the generator prompt so the LLM follows the new limit
- cover the new limit with tests across supported languages

## Testing
- python -m unittest discover

------
https://chatgpt.com/codex/tasks/task_e_68ce3bcb6aa883269336bf1c55b68798