### PR TITLE
Add dynamic fill-in crossword generator

### DIFF
--- a/tests/test_fill_in_generator.py
+++ b/tests/test_fill_in_generator.py
@@ -1,0 +1,66 @@
+"""Tests for the dynamic fill-in crossword generator."""
+
+from __future__ import annotations
+
+import pytest
+
+from utils.crossword import Direction
+from utils.fill_in_generator import FillInGenerationError, generate_fill_in_puzzle
+
+
+def _canonical(word: str, language: str) -> str:
+    transformed = word.strip().upper()
+    if language.lower() == "ru":
+        transformed = transformed.replace("Ё", "Е")
+    return transformed
+
+
+def test_generate_fill_in_puzzle_english_words() -> None:
+    puzzle = generate_fill_in_puzzle(
+        puzzle_id="test",
+        theme="Space",
+        language="en",
+        words=["planet", "orbit", "axis", "sun", "cosmos"],
+    )
+
+    assert puzzle.size_rows <= 15
+    assert puzzle.size_cols <= 15
+
+    answers = {slot.answer for slot in puzzle.slots}
+    for word in ["planet", "orbit", "axis", "sun", "cosmos"]:
+        assert _canonical(word, "en") in answers
+
+    assert any(slot.direction is Direction.ACROSS for slot in puzzle.slots)
+    assert any(slot.direction is Direction.DOWN for slot in puzzle.slots)
+
+    for row in puzzle.grid:
+        for cell in row:
+            assert cell.is_block == (cell.letter == "")
+
+
+def test_generate_fill_in_puzzle_russian_words() -> None:
+    words = ["парус", "лодка", "ветер", "берег"]
+    puzzle = generate_fill_in_puzzle(
+        puzzle_id="test_ru",
+        theme="Море",
+        language="ru",
+        words=words,
+    )
+
+    answers = {slot.answer for slot in puzzle.slots}
+    for word in words:
+        assert _canonical(word, "ru") in answers
+
+    assert puzzle.size_rows <= 15
+    assert puzzle.size_cols <= 15
+
+
+def test_generate_fill_in_puzzle_respects_max_size() -> None:
+    with pytest.raises(FillInGenerationError):
+        generate_fill_in_puzzle(
+            puzzle_id="tiny",
+            theme="Test",
+            language="en",
+            words=["alphabet", "letters", "symbols"],
+            max_size=4,
+        )

--- a/utils/fill_in_generator.py
+++ b/utils/fill_in_generator.py
@@ -1,0 +1,244 @@
+"""Dynamic fill-in style crossword generator.
+
+This module builds a crossword grid directly from a list of words without
+relying on a pre-defined block template. Words are sorted by length, the
+longest word is placed around the origin and the remaining ones are fitted
+either through intersections or, when impossible, by expanding the grid
+within the configured bounds.
+"""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from typing import Dict, List, Sequence, Tuple
+
+from utils.crossword import Cell, Direction, Puzzle, Slot, calculate_slots
+
+
+class FillInGenerationError(RuntimeError):
+    """Raised when the fill-in generator cannot place the provided words."""
+
+
+def _normalise_word(word: str, language: str) -> str:
+    normalised = word.strip().upper()
+    if language.lower() == "ru":
+        normalised = normalised.replace("Ё", "Е")
+    return normalised
+
+
+def _extract_answer(slot: Slot, grid: List[List[Cell]]) -> str:
+    letters: List[str] = []
+    for row, col in slot.coordinates():
+        letters.append(grid[row][col].letter)
+    return "".join(letters)
+
+
+def generate_fill_in_puzzle(
+    puzzle_id: str,
+    theme: str,
+    language: str,
+    words: Sequence[str],
+    *,
+    max_size: int = 15,
+) -> Puzzle:
+    """Create a crossword puzzle by dynamically arranging the provided words."""
+
+    if max_size < 1:
+        raise ValueError("max_size must be positive")
+
+    seen: set[str] = set()
+    normalised_words: List[str] = []
+    for word in words:
+        normalised = _normalise_word(word, language)
+        if not normalised:
+            continue
+        if normalised in seen:
+            continue
+        seen.add(normalised)
+        normalised_words.append(normalised)
+
+    if not normalised_words:
+        raise FillInGenerationError("No suitable words provided for generation")
+
+    normalised_words.sort(key=len, reverse=True)
+
+    grid_letters: Dict[Tuple[int, int], str] = {}
+    cell_directions: Dict[Tuple[int, int], set[Direction]] = defaultdict(set)
+    letter_positions: Dict[str, List[Tuple[int, int]]] = defaultdict(list)
+
+    bounds_initialised = False
+    min_row = max_row = min_col = max_col = 0
+
+    def update_bounds(row: int, col: int) -> None:
+        nonlocal bounds_initialised, min_row, max_row, min_col, max_col
+        if not bounds_initialised:
+            min_row = max_row = row
+            min_col = max_col = col
+            bounds_initialised = True
+            return
+        min_row = min(min_row, row)
+        max_row = max(max_row, row)
+        min_col = min(min_col, col)
+        max_col = max(max_col, col)
+
+    def would_exceed_bounds(
+        start_row: int, start_col: int, direction: Direction, length: int
+    ) -> bool:
+        if not bounds_initialised:
+            height = length if direction is Direction.DOWN else 1
+            width = length if direction is Direction.ACROSS else 1
+            return height > max_size or width > max_size
+
+        end_row = start_row + (length - 1 if direction is Direction.DOWN else 0)
+        end_col = start_col + (length - 1 if direction is Direction.ACROSS else 0)
+
+        candidate_min_row = min(min_row, start_row)
+        candidate_max_row = max(max_row, end_row)
+        candidate_min_col = min(min_col, start_col)
+        candidate_max_col = max(max_col, end_col)
+
+        height = candidate_max_row - candidate_min_row + 1
+        width = candidate_max_col - candidate_min_col + 1
+        return height > max_size or width > max_size
+
+    def can_place(
+        word: str,
+        start_row: int,
+        start_col: int,
+        direction: Direction,
+        require_intersection: bool,
+    ) -> bool:
+        if would_exceed_bounds(start_row, start_col, direction, len(word)):
+            return False
+
+        intersection_found = False
+        for idx, char in enumerate(word):
+            row = start_row + (idx if direction is Direction.DOWN else 0)
+            col = start_col + (idx if direction is Direction.ACROSS else 0)
+            existing = grid_letters.get((row, col))
+            if existing:
+                if existing != char:
+                    return False
+                if direction in cell_directions[(row, col)]:
+                    return False
+                intersection_found = True
+            else:
+                if direction is Direction.ACROSS:
+                    if grid_letters.get((row - 1, col)) or grid_letters.get((row + 1, col)):
+                        return False
+                else:
+                    if grid_letters.get((row, col - 1)) or grid_letters.get((row, col + 1)):
+                        return False
+
+            if direction is Direction.ACROSS:
+                if idx == 0 and grid_letters.get((row, col - 1)):
+                    return False
+                if idx == len(word) - 1 and grid_letters.get((row, col + 1)):
+                    return False
+            else:
+                if idx == 0 and grid_letters.get((row - 1, col)):
+                    return False
+                if idx == len(word) - 1 and grid_letters.get((row + 1, col)):
+                    return False
+
+        if require_intersection and not intersection_found:
+            return False
+        return True
+
+    def place_word(word: str, start_row: int, start_col: int, direction: Direction) -> None:
+        for idx, char in enumerate(word):
+            row = start_row + (idx if direction is Direction.DOWN else 0)
+            col = start_col + (idx if direction is Direction.ACROSS else 0)
+            grid_letters[(row, col)] = char
+            cell_directions[(row, col)].add(direction)
+            letter_positions[char].append((row, col))
+            update_bounds(row, col)
+
+    def try_place_word(word: str) -> bool:
+        # Prefer placements that intersect with existing words.
+        for idx, char in enumerate(word):
+            for row, col in letter_positions.get(char, []):
+                for direction in (Direction.ACROSS, Direction.DOWN):
+                    if direction in cell_directions[(row, col)]:
+                        continue
+                    start_row = row if direction is Direction.ACROSS else row - idx
+                    start_col = col - idx if direction is Direction.ACROSS else col
+                    if not can_place(word, start_row, start_col, direction, True):
+                        continue
+                    place_word(word, start_row, start_col, direction)
+                    return True
+
+        if not bounds_initialised:
+            return False
+
+        row_margin = max_size
+        col_margin = max_size
+        row_start = min_row - row_margin
+        row_end = max_row + row_margin
+        col_start = min_col - col_margin
+        col_end = max_col + col_margin
+
+        for direction in (Direction.ACROSS, Direction.DOWN):
+            for row in range(row_start, row_end + 1):
+                for col in range(col_start, col_end + 1):
+                    start_row = row
+                    start_col = col
+                    if not can_place(word, start_row, start_col, direction, False):
+                        continue
+                    place_word(word, start_row, start_col, direction)
+                    return True
+        return False
+
+    first_word = normalised_words[0]
+    horizontal_start_col = -(len(first_word) // 2)
+    place_word(first_word, 0, horizontal_start_col, Direction.ACROSS)
+
+    for word in normalised_words[1:]:
+        if not try_place_word(word):
+            raise FillInGenerationError(f"Failed to place word: {word}")
+
+    rows = max_row - min_row + 1
+    cols = max_col - min_col + 1
+    if rows > max_size or cols > max_size:
+        raise FillInGenerationError("Generated grid exceeds allowed dimensions")
+
+    grid: List[List[Cell]] = []
+    for row in range(rows):
+        row_cells: List[Cell] = []
+        actual_row = row + min_row
+        for col in range(cols):
+            actual_col = col + min_col
+            letter = grid_letters.get((actual_row, actual_col), "")
+            row_cells.append(
+                Cell(
+                    row=row,
+                    col=col,
+                    is_block=letter == "",
+                    letter=letter,
+                )
+            )
+        grid.append(row_cells)
+
+    puzzle = Puzzle(
+        id=puzzle_id,
+        theme=theme,
+        language=language,
+        size_rows=rows,
+        size_cols=cols,
+        grid=grid,
+    )
+
+    puzzle.slots = calculate_slots(puzzle)
+
+    for row_cells in puzzle.grid:
+        for cell in row_cells:
+            cell.source_slots.clear()
+
+    for slot in puzzle.slots:
+        answer = _extract_answer(slot, puzzle.grid)
+        slot.answer = answer
+        for row, col in slot.coordinates():
+            puzzle.grid[row][col].source_slots.add(slot.slot_id)
+
+    return puzzle
+


### PR DESCRIPTION
## Summary
- add a fill-in style generator that builds a crossword grid directly from the provided words and records slot answers
- integrate the new generator into puzzle creation with a size limit and persist the generated puzzle
- cover the generator with tests for multiple languages and dimension limits

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cfdfa323c88326898249aa3754d291