### PR TITLE
Support composite puzzles and component-aware commands

### DIFF
--- a/tests/test_composite.py
+++ b/tests/test_composite.py
@@ -1,0 +1,44 @@
+from app import _build_word_components, _resolve_slot
+from utils.crossword import CompositeComponent, CompositePuzzle
+from utils.fill_in_generator import generate_fill_in_puzzle
+from utils.llm_generator import WordClue
+
+
+def test_build_word_components_detects_disconnected_groups():
+    clues = [
+        WordClue(word="cat", clue=""),
+        WordClue(word="tack", clue=""),
+        WordClue(word="dog", clue=""),
+        WordClue(word="good", clue=""),
+    ]
+
+    components = _build_word_components(clues, "en")
+    assert len(components) == 2
+    words_by_component = [sorted(clue.word for clue in group) for group in components]
+    assert sorted(words_by_component) == [["cat", "tack"], ["dog", "good"]]
+
+
+def test_resolve_slot_requires_component_suffix():
+    puzzle1 = generate_fill_in_puzzle("p1", "theme", "en", ["alpha"])
+    puzzle2 = generate_fill_in_puzzle("p2", "theme", "en", ["omega"])
+    composite = CompositePuzzle(
+        id="comp",
+        theme="theme",
+        language="en",
+        components=[
+            CompositeComponent(index=1, puzzle=puzzle1, row_offset=0, col_offset=0),
+            CompositeComponent(index=2, puzzle=puzzle2, row_offset=puzzle1.size_rows + 1, col_offset=0),
+        ],
+        gap_cells=1,
+    )
+
+    slot_ref, message = _resolve_slot(composite, "A1")
+    assert slot_ref is None
+    assert message is not None
+    assert "A1-1" in message and "A1-2" in message
+
+    slot_ref, message = _resolve_slot(composite, "A1-2")
+    assert message is None
+    assert slot_ref is not None
+    assert slot_ref.component_index == 2
+    assert slot_ref.slot.slot_id == "A1"

--- a/utils/storage.py
+++ b/utils/storage.py
@@ -38,6 +38,7 @@ class GameState:
     started_at: float
     last_update: float
     hinted_cells: set[str] | None = None
+    puzzle_ids: list[str] | None = None
 
     def to_dict(self) -> Dict[str, Any]:
         """Serialize the state into a JSON-compatible dictionary."""
@@ -45,6 +46,7 @@ class GameState:
         return {
             "chat_id": self.chat_id,
             "puzzle_id": self.puzzle_id,
+            "puzzle_ids": list(self.puzzle_ids) if self.puzzle_ids else None,
             "filled_cells": self.filled_cells,
             "solved_slots": sorted(self.solved_slots),
             "score": self.score,
@@ -65,9 +67,19 @@ class GameState:
         else:
             solved_slots = set()
 
+        puzzle_ids_raw = payload.get("puzzle_ids")
+        puzzle_ids: list[str] | None
+        if isinstance(puzzle_ids_raw, Iterable) and not isinstance(puzzle_ids_raw, (str, bytes)):
+            puzzle_ids = [str(item) for item in puzzle_ids_raw]
+        elif puzzle_ids_raw:
+            puzzle_ids = [str(puzzle_ids_raw)]
+        else:
+            puzzle_ids = None
+
         return cls(
             chat_id=int(payload["chat_id"]),
             puzzle_id=str(payload["puzzle_id"]),
+            puzzle_ids=puzzle_ids,
             filled_cells=dict(payload.get("filled_cells", {})),
             solved_slots=solved_slots,
             score=int(payload.get("score", 0)),


### PR DESCRIPTION
## Summary
- detect disconnected word clusters and fall back to composite crossword generation when fill-in fails
- update rendering, state handling, and commands to work with composite puzzles and component-aware slot IDs
- add unit tests covering component splitting and slot resolution for composite grids

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cfe1ddcef88326b344bf4d5b11b038