### PR TITLE
Handle inline answers for crossword bot

### DIFF
--- a/tests/test_inline_answers.py
+++ b/tests/test_inline_answers.py
@@ -1,0 +1,35 @@
+"""Tests for inline answer parsing."""
+
+import pytest
+
+from app import _parse_inline_answer
+
+
+@pytest.mark.parametrize(
+    ("text", "expected"),
+    [
+        ("A1 - Tokyo", ("A1", "Tokyo")),
+        (" b12 –  Kyoto ", ("B12", "Kyoto")),
+        ("c3:Rio", ("C3", "Rio")),
+    ],
+)
+def test_parse_inline_answer_valid(text, expected):
+    assert _parse_inline_answer(text) == expected
+
+
+@pytest.mark.parametrize(
+    "text",
+    [
+        "",
+        "  ",
+        "A1",
+        "A1-",
+        "- Tokyo",
+        "123 - foo",
+        "A - foo",
+        "A1 - ",
+        "слово без слота",
+    ],
+)
+def test_parse_inline_answer_invalid(text):
+    assert _parse_inline_answer(text) is None


### PR DESCRIPTION
## Summary
- teach the bot to parse inline answer messages and reuse the shared submission helper
- inform players of the inline answer format when a puzzle is delivered
- cover the new inline parsing helper with tests

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d6a9d3021883268cbee23829949a1a