### PR TITLE
Handle disconnected fill-in words with replacements

### DIFF
--- a/tests/test_fill_in_generator.py
+++ b/tests/test_fill_in_generator.py
@@ -5,7 +5,11 @@ from __future__ import annotations
 import pytest
 
 from utils.crossword import Direction
-from utils.fill_in_generator import FillInGenerationError, generate_fill_in_puzzle
+from utils.fill_in_generator import (
+    DisconnectedWordError,
+    FillInGenerationError,
+    generate_fill_in_puzzle,
+)
 
 
 def _canonical(word: str, language: str) -> str:
@@ -16,18 +20,19 @@ def _canonical(word: str, language: str) -> str:
 
 
 def test_generate_fill_in_puzzle_english_words() -> None:
+    words = ["asteroid", "saturn", "radar", "star", "nova"]
     puzzle = generate_fill_in_puzzle(
         puzzle_id="test",
         theme="Space",
         language="en",
-        words=["planet", "orbit", "axis", "sun", "cosmos"],
+        words=words,
     )
 
     assert puzzle.size_rows <= 15
     assert puzzle.size_cols <= 15
 
     answers = {slot.answer for slot in puzzle.slots}
-    for word in ["planet", "orbit", "axis", "sun", "cosmos"]:
+    for word in words:
         assert _canonical(word, "en") in answers
 
     assert any(slot.direction is Direction.ACROSS for slot in puzzle.slots)
@@ -37,9 +42,17 @@ def test_generate_fill_in_puzzle_english_words() -> None:
         for cell in row:
             assert cell.is_block == (cell.letter == "")
 
+    for slot in puzzle.slots:
+        intersects = False
+        for row, col in slot.coordinates():
+            if len(puzzle.grid[row][col].source_slots) > 1:
+                intersects = True
+                break
+        assert intersects, f"Slot {slot.slot_id} must intersect with another word"
+
 
 def test_generate_fill_in_puzzle_russian_words() -> None:
-    words = ["парус", "лодка", "ветер", "берег"]
+    words = ["парус", "палуба", "баркас", "якорь"]
     puzzle = generate_fill_in_puzzle(
         puzzle_id="test_ru",
         theme="Море",
@@ -53,6 +66,16 @@ def test_generate_fill_in_puzzle_russian_words() -> None:
 
     assert puzzle.size_rows <= 15
     assert puzzle.size_cols <= 15
+
+
+def test_generate_fill_in_puzzle_requires_intersections() -> None:
+    with pytest.raises(DisconnectedWordError):
+        generate_fill_in_puzzle(
+            puzzle_id="disconnected",
+            theme="Test",
+            language="en",
+            words=["aaa", "bbb", "ccc"],
+        )
 
 
 def test_generate_fill_in_puzzle_respects_max_size() -> None:


### PR DESCRIPTION
## Summary
- remove the non-intersecting placement fallback in the fill-in generator and raise a dedicated DisconnectedWordError
- request additional LLM clues to replace disconnected words during puzzle generation until the grid is connected or attempts are exhausted
- update fill-in generator tests to assert intersections for every slot and cover the new disconnected-word error path

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d6c7f7ab7c8326bfb834678b571b05