### PR TITLE
Expand inline answer parsing for multilingual slot IDs

### DIFF
--- a/app.py
+++ b/app.py
@@ -256,7 +256,10 @@ def _normalise_slot_id(slot_id: str) -> str:
     return slot_id.strip().upper()
 
 
-INLINE_ANSWER_PATTERN = re.compile(r"^\s*([A-Za-z]+[0-9]+)\s*[-–:]\s*(.+)$")
+INLINE_ANSWER_PATTERN = re.compile(
+    r"^\s*([^\W\d_]+[0-9]+(?:-[0-9]+)?)\s*[-–:]\s*(.+)$",
+    flags=re.UNICODE,
+)
 
 
 def _parse_inline_answer(text: str | None) -> Optional[tuple[str, str]]:


### PR DESCRIPTION
## Summary
- broaden the inline answer regex to accept lettered identifiers from any alphabet plus optional component suffixes
- keep the inline answer handler registration aligned with the shared regex constant
- extend inline answer tests to cover unicode/component IDs and to ensure the handler forwards the parsed slot and answer

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d6cf15196083269d69bf61f82242bc