### PR TITLE
Allow Cyrillic A and D in answer slot IDs

### DIFF
--- a/app.py
+++ b/app.py
@@ -252,8 +252,13 @@ def _coord_key(row: int, col: int, component: int | None = None) -> str:
     return f"{component}:{base}"
 
 
+CYRILLIC_SLOT_LETTER_MAP = str.maketrans({"А": "A", "Д": "D"})
+
+
 def _normalise_slot_id(slot_id: str) -> str:
-    return slot_id.strip().upper()
+    """Normalise slot identifiers to a canonical ASCII form."""
+
+    return slot_id.strip().upper().translate(CYRILLIC_SLOT_LETTER_MAP)
 
 
 INLINE_ANSWER_PATTERN = re.compile(

--- a/tests/test_inline_answers.py
+++ b/tests/test_inline_answers.py
@@ -15,6 +15,8 @@ from app import _parse_inline_answer, inline_answer_handler
         ("A1 - Tokyo", ("A1", "Tokyo")),
         (" b12 –  Kyoto ", ("B12", "Kyoto")),
         ("c3:Rio", ("C3", "Rio")),
+        ("А1 - ответ", ("A1", "ответ")),
+        ("д7 - слово", ("D7", "слово")),
         ("я5 - Ответ", ("Я5", "Ответ")),
         ("β12-3:Αθήνα", ("Β12-3", "Αθήνα")),
         (" z9-2 :  respuesta ", ("Z9-2", "respuesta")),


### PR DESCRIPTION
## Summary
- normalise slot identifiers by translating Cyrillic А and Д to their Latin counterparts so answers accept Russian prefixes
- extend inline answer parsing tests to cover Cyrillic slot identifiers

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d805a06d448326b5720c7b300adc00