### PR TITLE
Handle em dashes in inline answers

### DIFF
--- a/app.py
+++ b/app.py
@@ -282,7 +282,8 @@ def _normalise_slot_id(slot_id: str) -> str:
 
 
 INLINE_ANSWER_PATTERN = re.compile(
-    r"^\s*([^\W\d_]+[0-9]+(?:-[0-9]+)?)\s*[-–:]\s*(.+)$",
+    # Accept common dash-like separators (hyphen, en/em dash, figure dash, minus) and colon
+    r"^\s*([^\W\d_]+[0-9]+(?:-[0-9]+)?)\s*[-–—‒−:]\s*(.+)$",
     flags=re.UNICODE,
 )
 

--- a/tests/test_inline_answers.py
+++ b/tests/test_inline_answers.py
@@ -20,6 +20,7 @@ from app import _parse_inline_answer, inline_answer_handler
         ("я5 - Ответ", ("Я5", "Ответ")),
         ("β12-3:Αθήνα", ("Β12-3", "Αθήνα")),
         (" z9-2 :  respuesta ", ("Z9-2", "respuesta")),
+        ("A2 — мопс", ("A2", "мопс")),
     ],
 )
 def test_parse_inline_answer_valid(text, expected):


### PR DESCRIPTION
## Summary
- expand the inline answer parsing regex to accept additional dash-like separators such as the em dash
- extend the inline answer parsing tests to cover em dash inputs

## Testing
- pytest tests/test_inline_answers.py

------
https://chatgpt.com/codex/tasks/task_e_68d84edb79bc8326b11f98a08551d107