### PR TITLE
Support additional hyphen characters in inline answers

### DIFF
--- a/app.py
+++ b/app.py
@@ -282,8 +282,8 @@ def _normalise_slot_id(slot_id: str) -> str:
 
 
 INLINE_ANSWER_PATTERN = re.compile(
-    # Accept common dash-like separators (hyphen, en/em dash, figure dash, minus) and colon
-    r"^\s*([^\W\d_]+[0-9]+(?:-[0-9]+)?)\s*[-–—‒−:]\s*(.+)$",
+    # Accept common dash-like separators (hyphen-minus, hyphen, non-breaking hyphen, en/em dash, figure dash, minus) and colon
+    r"^\s*([^\W\d_]+[0-9]+(?:-[0-9]+)?)\s*[-‐‑–—‒−:]\s*(.+)$",
     flags=re.UNICODE,
 )
 

--- a/tests/test_inline_answers.py
+++ b/tests/test_inline_answers.py
@@ -21,6 +21,7 @@ from app import _parse_inline_answer, inline_answer_handler
         ("β12-3:Αθήνα", ("Β12-3", "Αθήνα")),
         (" z9-2 :  respuesta ", ("Z9-2", "respuesta")),
         ("A2 — мопс", ("A2", "мопс")),
+        ("F5 ‑ Oslo", ("F5", "Oslo")),
     ],
 )
 def test_parse_inline_answer_valid(text, expected):


### PR DESCRIPTION
## Summary
- extend the inline answer regex to accept Unicode hyphen and non-breaking hyphen separators
- add a regression test covering one of the new hyphen variants to keep the parser behavior stable

## Testing
- pytest tests/test_inline_answers.py

------
https://chatgpt.com/codex/tasks/task_e_68d8d1f093e4832695f7556fcf72cd3c