### PR TITLE
Add quit command handler to Telegram dispatcher

### DIFF
--- a/app.py
+++ b/app.py
@@ -1806,6 +1806,7 @@ def configure_telegram_handlers(telegram_application: Application) -> None:
     telegram_application.add_handler(CommandHandler("answer", answer_command))
     telegram_application.add_handler(CommandHandler(["hint", "open"], hint_command))
     telegram_application.add_handler(CommandHandler("solve", solve_command))
+    telegram_application.add_handler(CommandHandler("quit", quit_command))
     telegram_application.add_handler(CommandHandler("cancel", cancel_new_game))
     telegram_application.add_handler(
         MessageHandler(filters.Regex(INLINE_ANSWER_PATTERN), inline_answer_handler)

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -1,0 +1,23 @@
+"""Tests for Telegram handler configuration."""
+
+from unittest.mock import MagicMock
+
+from telegram.ext import CommandHandler
+
+from app import configure_telegram_handlers, quit_command
+
+
+def test_configure_handlers_includes_quit_command() -> None:
+    """The dispatcher should register the /quit command."""
+
+    telegram_application = MagicMock()
+
+    configure_telegram_handlers(telegram_application)
+
+    quit_handlers = [
+        call.args[0]
+        for call in telegram_application.add_handler.call_args_list
+        if isinstance(call.args[0], CommandHandler) and "quit" in call.args[0].commands
+    ]
+
+    assert any(handler.callback is quit_command for handler in quit_handlers)


### PR DESCRIPTION
## Summary
- register the /quit command with the Telegram dispatcher alongside other commands
- add a unit test ensuring configure_telegram_handlers wires the quit command handler

## Testing
- pytest tests/test_handlers.py

------
https://chatgpt.com/codex/tasks/task_e_68d8d1e992bc8326a3546a0e1b48807a