### PR TITLE
Fix button new-game flow state shadowing

### DIFF
--- a/app.py
+++ b/app.py
@@ -1230,8 +1230,8 @@ async def button_theme_handler(update: Update, context: ContextTypes.DEFAULT_TYP
     _normalise_thread_id(update)
     if not await _reject_group_chat(update):
         return
-    state = context.chat_data.get(BUTTON_NEW_GAME_KEY)
-    if not state or state.get(BUTTON_STEP_KEY) != BUTTON_STEP_THEME:
+    flow_state = context.chat_data.get(BUTTON_NEW_GAME_KEY)
+    if not flow_state or flow_state.get(BUTTON_STEP_KEY) != BUTTON_STEP_THEME:
         return
     message = update.effective_message
     chat = update.effective_chat
@@ -1242,10 +1242,10 @@ async def button_theme_handler(update: Update, context: ContextTypes.DEFAULT_TYP
             "Мы всё ещё готовим ваш предыдущий кроссворд. Пожалуйста, подождите."
         )
         return
-    language = state.get(BUTTON_LANGUAGE_KEY)
+    language = flow_state.get(BUTTON_LANGUAGE_KEY)
     if not language:
         await message.reply_text("Сначала выберите язык через команду /new.")
-        state[BUTTON_STEP_KEY] = BUTTON_STEP_LANGUAGE
+        flow_state[BUTTON_STEP_KEY] = BUTTON_STEP_LANGUAGE
         return
     theme = message.text.strip()
     if not theme:

--- a/tests/test_button_flow.py
+++ b/tests/test_button_flow.py
@@ -1,0 +1,107 @@
+"""Tests covering the button-driven new game flow."""
+
+from __future__ import annotations
+
+import time
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+from telegram.constants import ChatType
+
+import app
+from app import (
+    BUTTON_LANGUAGE_KEY,
+    BUTTON_NEW_GAME_KEY,
+    BUTTON_STEP_KEY,
+    BUTTON_STEP_THEME,
+    GENERATION_NOTICE_KEY,
+    button_theme_handler,
+    state,
+)
+from utils.crossword import Puzzle
+from utils.storage import GameState
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+class DummyJob:
+    def __init__(self, chat_id: int, name: str) -> None:
+        self.chat_id = chat_id
+        self.name = name
+        self.cancelled = False
+
+    def schedule_removal(self) -> None:
+        self.cancelled = True
+
+
+class DummyJobQueue:
+    def __init__(self) -> None:
+        self.submitted: list[tuple] = []
+
+    def run_once(self, callback, when, *, chat_id: int, name: str):  # noqa: ANN001 - signature mimics library
+        job = DummyJob(chat_id, name)
+        self.submitted.append((callback, when, chat_id, name))
+        return job
+
+
+@pytest.mark.anyio
+async def test_button_theme_handler_generates_puzzle_via_completion_menu(monkeypatch):
+    chat_id = 789
+    puzzle = Puzzle.from_size("test-puzzle", "История", "ru", 3, 3)
+    now = time.time()
+    game_state = GameState(
+        chat_id=chat_id,
+        puzzle_id=puzzle.id,
+        filled_cells={},
+        solved_slots=set(),
+        score=0,
+        hints_used=0,
+        started_at=now,
+        last_update=now,
+    )
+
+    generate_calls: list[tuple[int, str, str]] = []
+
+    def fake_generate(request_chat_id: int, language: str, theme: str):
+        generate_calls.append((request_chat_id, language, theme))
+        return puzzle, game_state
+
+    monkeypatch.setattr(app, "_generate_puzzle", fake_generate)
+    deliver_mock = AsyncMock(return_value=True)
+    monkeypatch.setattr(app, "_deliver_puzzle_via_bot", deliver_mock)
+
+    message = SimpleNamespace(text="  Древний мир  ", message_thread_id=None, reply_text=AsyncMock())
+    chat = SimpleNamespace(id=chat_id, type=ChatType.PRIVATE)
+
+    previous_job = DummyJob(chat_id, "old-job")
+    job_queue = DummyJobQueue()
+    context = SimpleNamespace(
+        bot=SimpleNamespace(),
+        chat_data={
+            BUTTON_NEW_GAME_KEY: {
+                BUTTON_STEP_KEY: BUTTON_STEP_THEME,
+                BUTTON_LANGUAGE_KEY: "ru",
+            },
+            "reminder_job": previous_job,
+        },
+        job_queue=job_queue,
+    )
+    update = SimpleNamespace(effective_chat=chat, effective_message=message)
+
+    state.generating_chats.clear()
+
+    await button_theme_handler(update, context)
+
+    assert generate_calls == [(chat_id, "ru", "Древний мир")]
+    deliver_mock.assert_awaited_once_with(context, chat_id, puzzle, game_state)
+    assert BUTTON_NEW_GAME_KEY not in context.chat_data
+    assert GENERATION_NOTICE_KEY not in context.chat_data
+    assert chat_id not in state.generating_chats
+    assert previous_job.cancelled is True
+    assert len(job_queue.submitted) == 1
+    assert context.chat_data["reminder_job"].name.startswith("hint-reminder-")
+    message.reply_text.assert_awaited()


### PR DESCRIPTION
## Summary
- rename the button flow chat-data variable in `button_theme_handler` to avoid shadowing the global application state container
- add a regression test that exercises the button-driven completion flow to ensure a new puzzle can be generated without raising

## Testing
- pytest tests/test_button_flow.py


------
https://chatgpt.com/codex/tasks/task_e_68d8ee15d3808326819bafa5da7b0358