### PR TITLE
Ensure theme handler clears language flag during generation wait

### DIFF
--- a/tests/test_inline_answers.py
+++ b/tests/test_inline_answers.py
@@ -6,7 +6,9 @@ from unittest.mock import AsyncMock, patch
 import pytest
 from telegram.constants import ChatType
 
-from app import _parse_inline_answer, inline_answer_handler
+from telegram.ext import ConversationHandler
+
+from app import _parse_inline_answer, handle_theme, inline_answer_handler, state
 
 
 @pytest.mark.parametrize(
@@ -63,3 +65,41 @@ async def test_inline_handler_passes_parsed_values_to_submission_handler():
         await inline_answer_handler(update, context)
 
     handler_mock.assert_awaited_once_with(context, chat, message, "Β12-3", "Αθήνα")
+
+
+@pytest.mark.anyio
+async def test_inline_answer_allowed_after_extra_theme_during_generation():
+    chat = SimpleNamespace(id=777, type=ChatType.PRIVATE)
+    theme_message = SimpleNamespace(
+        text="Космос",
+        message_thread_id=None,
+        reply_text=AsyncMock(),
+    )
+    update = SimpleNamespace(effective_chat=chat, effective_message=theme_message)
+    context = SimpleNamespace(user_data={"new_game_language": "ru"}, chat_data={}, job_queue=None)
+
+    state.generating_chats.add(chat.id)
+    try:
+        with patch("app._reject_group_chat", new=AsyncMock(return_value=True)):
+            result = await handle_theme(update, context)
+
+        assert result == ConversationHandler.END
+        theme_message.reply_text.assert_awaited_once()
+        assert "new_game_language" not in context.user_data
+
+        # Simulate puzzle generation finishing and player sending an inline answer.
+        state.generating_chats.discard(chat.id)
+        answer_message = SimpleNamespace(
+            text="A1 - ответ",
+            message_thread_id=None,
+            reply_text=AsyncMock(),
+        )
+        answer_update = SimpleNamespace(effective_chat=chat, effective_message=answer_message)
+
+        with patch("app._reject_group_chat", new=AsyncMock(return_value=True)):
+            with patch("app._handle_answer_submission", new_callable=AsyncMock) as handler_mock:
+                await inline_answer_handler(answer_update, context)
+
+        handler_mock.assert_awaited_once_with(context, chat, answer_message, "A1", "ответ")
+    finally:
+        state.generating_chats.discard(chat.id)


### PR DESCRIPTION
## Summary
- ensure the theme handler always clears the `new_game_language` flag when the conversation ends, including while a puzzle is generating
- keep the inline answer flow available after generation by guarding cleanup with a `finally`
- add a regression test that covers sending a duplicate theme message during generation and then submitting an inline answer

## Testing
- pytest tests/test_inline_answers.py

------
https://chatgpt.com/codex/tasks/task_e_68d924ec3f6883269c19f790318a5eef