### PR TITLE
Adjust clue generation bounds for replacements

### DIFF
--- a/app.py
+++ b/app.py
@@ -2245,7 +2245,12 @@ def _generate_puzzle(
                     replacement_requests,
                     prompt_suffix,
                 )
-                new_clues = generate_clues(theme=replacement_theme, language=language)
+                new_clues = generate_clues(
+                    theme=replacement_theme,
+                    language=language,
+                    min_results=6,
+                    max_results=8,
+                )
                 new_validated = validate_word_list(language, new_clues, deduplicate=True)
                 logger.info(
                     "Validated %s replacement candidates", len(new_validated)

--- a/tests/test_component_selection.py
+++ b/tests/test_component_selection.py
@@ -43,7 +43,14 @@ def test_generate_puzzle_uses_connected_subset(monkeypatch: pytest.MonkeyPatch) 
     target_component = {clue.word for clue in connected_cluster}
     captured_words: list[str] = []
 
-    def fake_generate_clues(theme: str, language: str) -> list[WordClue]:
+    def fake_generate_clues(
+        theme: str,
+        language: str,
+        *,
+        min_results: int = 10,
+        max_results: int = 40,
+    ) -> list[WordClue]:
+        assert (min_results, max_results) == (10, 40)
         return disconnected_order
 
     def fake_validate_word_list(


### PR DESCRIPTION
## Summary
- allow the clue generator to accept configurable minimum and maximum sizes instead of hard-coding 10–40
- request smaller batches when fetching replacement clues and keep the existing heuristics intact
- update the component and replacement selection tests to assert the new parameters and cover 6–8 candidate scenarios

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68db862854188326acf6ffff013bb684