### PR TITLE
Fix test game cleanup and add storage tests

### DIFF
--- a/app.py
+++ b/app.py
@@ -257,7 +257,7 @@ def _cleanup_game_state(game_state: GameState | None) -> None:
         task = state.lobby_generation_tasks.pop(game_state.game_id, None)
         if task is not None:
             task.cancel()
-        delete_state(game_state)
+        delete_state(game_state.game_id)
         for code, target in list(state.join_codes.items()):
             if target == game_state.game_id:
                 state.join_codes.pop(code, None)

--- a/tests/test_storage_cleanup.py
+++ b/tests/test_storage_cleanup.py
@@ -1,0 +1,46 @@
+"""Tests for storage cleanup helpers."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from _pytest.monkeypatch import MonkeyPatch
+
+from utils import storage
+
+
+def test_delete_state_preserves_base_game_when_removing_test(
+    tmp_path, monkeypatch: MonkeyPatch
+) -> None:
+    """Deleting a test game must not remove the base state file."""
+
+    tmp_states: Path = tmp_path
+    admin_game_id = "admin:42"
+    base_game_id = "42"
+
+    admin_file = tmp_states / f"{admin_game_id}{storage.STATE_FILE_SUFFIX}"
+    base_file = tmp_states / f"{base_game_id}{storage.STATE_FILE_SUFFIX}"
+    admin_file.write_text("{}", encoding="utf-8")
+    base_file.write_text("{}", encoding="utf-8")
+
+    monkeypatch.setattr(storage, "STATES_DIR", tmp_states)
+    storage.delete_state(admin_game_id)
+
+    assert not admin_file.exists(), "Test game state should be removed"
+    assert base_file.exists(), "Base game state must persist after test cleanup"
+
+
+def test_delete_state_removes_legacy_chat_file(
+    tmp_path, monkeypatch: MonkeyPatch
+) -> None:
+    """Deleting a normal game should also remove its legacy chat-id file."""
+
+    tmp_states: Path = tmp_path
+    game_id = "0000012345"
+    legacy_chat_file = tmp_states / f"{int(game_id)}{storage.STATE_FILE_SUFFIX}"
+    legacy_chat_file.write_text("{}", encoding="utf-8")
+
+    monkeypatch.setattr(storage, "STATES_DIR", tmp_states)
+    storage.delete_state(game_id)
+
+    assert not legacy_chat_file.exists(), "Legacy chat state should be removed"


### PR DESCRIPTION
## Summary
- ensure `_cleanup_game_state` only deletes the persisted state for the specific game id
- add tests covering admin test cleanup and legacy chat file deletion in `delete_state`

## Testing
- pytest tests/test_storage_cleanup.py

------
https://chatgpt.com/codex/tasks/task_e_68dc3e419c288326a86c71608da9a233