### PR TITLE
Persist topic thread ids in multiplayer announcements

### DIFF
--- a/app.py
+++ b/app.py
@@ -190,6 +190,7 @@ class AppState:
         self.lobby_messages: dict[str, tuple[int, int]] = {}
         self.scheduled_jobs: dict[str, Job] = {}
         self.lobby_generation_tasks: dict[str, asyncio.Task[None]] = {}
+        self.chat_threads: dict[int, int] = {}
 
 
 state = AppState()
@@ -434,12 +435,22 @@ def _normalise_thread_id(update: Update) -> int:
     thread_id = 0
     if message is not None and message.message_thread_id is not None:
         thread_id = message.message_thread_id
+    chat = update.effective_chat
+    if chat is not None and thread_id > 0:
+        state.chat_threads[chat.id] = thread_id
     logger.debug(
         "Normalised thread id for chat %s: %s",
         update.effective_chat.id if update.effective_chat else "<unknown>",
         thread_id,
     )
     return thread_id
+
+
+def _thread_kwargs(game_state: GameState) -> dict[str, int]:
+    thread_id = getattr(game_state, "thread_id", 0) or 0
+    if thread_id > 0:
+        return {"message_thread_id": thread_id}
+    return {}
 
 
 def _format_duration(seconds: float) -> str:
@@ -993,7 +1004,11 @@ async def _dummy_turn_job(context: CallbackContext) -> None:
     )
     message_text = f"{info_prefix}: /answer {slot_ref.public_id} {attempt_answer}"
     try:
-        await context.bot.send_message(chat_id=game_state.chat_id, text=message_text)
+        await context.bot.send_message(
+            chat_id=game_state.chat_id,
+            text=message_text,
+            **_thread_kwargs(game_state),
+        )
     except Exception:  # noqa: BLE001
         logger.exception(
             "Failed to announce dummy answer attempt in game %s", game_state.game_id
@@ -1025,7 +1040,9 @@ async def _dummy_turn_job(context: CallbackContext) -> None:
         )
         try:
             await context.bot.send_message(
-                chat_id=game_state.chat_id, text=success_text
+                chat_id=game_state.chat_id,
+                text=success_text,
+                **_thread_kwargs(game_state),
             )
         except Exception:  # noqa: BLE001
             logger.exception(
@@ -1050,7 +1067,11 @@ async def _dummy_turn_job(context: CallbackContext) -> None:
     _cancel_turn_timers(game_state)
     failure_text = f"{info_prefix} ошибся на {slot_ref.public_id}."
     try:
-        await context.bot.send_message(chat_id=game_state.chat_id, text=failure_text)
+        await context.bot.send_message(
+            chat_id=game_state.chat_id,
+            text=failure_text,
+            **_thread_kwargs(game_state),
+        )
     except Exception:  # noqa: BLE001
         logger.exception(
             "Failed to notify about dummy failure in game %s", game_state.game_id
@@ -1146,6 +1167,7 @@ async def _announce_turn(
             chat_id=game_state.chat_id,
             text=text,
             reply_markup=keyboard,
+            **_thread_kwargs(game_state),
         )
     except Exception:  # noqa: BLE001
         logger.exception("Failed to announce turn in group for game %s", game_state.game_id)
@@ -1206,7 +1228,11 @@ async def _handle_turn_timeout(
     if player:
         message = f"{player.name} не успел ответить. Ход переходит дальше."
     try:
-        await context.bot.send_message(chat_id=game_state.chat_id, text=message)
+        await context.bot.send_message(
+            chat_id=game_state.chat_id,
+            text=message,
+            **_thread_kwargs(game_state),
+        )
     except Exception:  # noqa: BLE001
         logger.exception("Failed to notify about turn timeout for game %s", game_state.game_id)
     _advance_turn(game_state)
@@ -1354,6 +1380,7 @@ async def _finish_game(
             text="\n".join(lines),
             parse_mode=constants.ParseMode.HTML,
             reply_markup=keyboard,
+            **_thread_kwargs(game_state),
         )
     except Exception:  # noqa: BLE001
         logger.exception("Failed to send finish summary for game %s", game_state.game_id)
@@ -1541,6 +1568,7 @@ async def _publish_lobby_message(
         chat_id=chat_id,
         text=text,
         reply_markup=keyboard,
+        **_thread_kwargs(game_state),
     )
     state.lobby_messages[game_state.game_id] = (chat_id, sent.message_id)
 
@@ -1583,7 +1611,12 @@ async def _run_lobby_puzzle_generation(
     generated_state: GameState | None = None
     try:
         puzzle, generated_state = await loop.run_in_executor(
-            None, _generate_puzzle, chat_id, language, theme
+            None,
+            _generate_puzzle,
+            chat_id,
+            language,
+            theme,
+            base_state.thread_id if getattr(base_state, "thread_id", 0) else 0,
         )
     except asyncio.CancelledError:
         logger.info("Lobby puzzle generation cancelled for game %s", game_id)
@@ -1615,6 +1648,7 @@ async def _run_lobby_puzzle_generation(
                 text=(
                     "Не удалось подготовить кроссворд. Попробуйте выбрать тему ещё раз."
                 ),
+                **(_thread_kwargs(refreshed) if refreshed else {}),
             )
         except TelegramError:
             logger.exception("Failed to notify chat %s about generation failure", chat_id)
@@ -1669,6 +1703,7 @@ async def _run_lobby_puzzle_generation(
             await context.bot.send_message(
                 chat_id=chat_id,
                 text="Кроссворд готов! Нажмите «Старт», чтобы начать игру.",
+                **_thread_kwargs(refreshed),
             )
         except TelegramError:
             logger.exception(
@@ -1681,7 +1716,14 @@ def _load_state_by_game_id(game_id: str) -> GameState | None:
     if not game_id:
         return None
     if game_id in state.active_games:
-        return state.active_games[game_id]
+        cached = state.active_games[game_id]
+        hint_thread = state.chat_threads.get(cached.chat_id, 0)
+        if _maybe_update_thread_binding(cached, hint_thread):
+            state.chat_threads[cached.chat_id] = cached.thread_id
+            save_state(cached)
+        elif getattr(cached, "thread_id", 0) > 0:
+            state.chat_threads[cached.chat_id] = cached.thread_id
+        return cached
     restored = load_state(game_id)
     if restored is None:
         return None
@@ -1692,6 +1734,12 @@ def _load_state_by_game_id(game_id: str) -> GameState | None:
             state.join_codes.pop(code, None)
     for code, target in restored.join_codes.items():
         state.join_codes[code] = target
+    hint_thread = state.chat_threads.get(restored.chat_id, 0)
+    if _maybe_update_thread_binding(restored, hint_thread):
+        state.chat_threads[restored.chat_id] = restored.thread_id
+        save_state(restored)
+    elif getattr(restored, "thread_id", 0) > 0:
+        state.chat_threads[restored.chat_id] = restored.thread_id
     return restored
 
 
@@ -1740,6 +1788,17 @@ async def track_player_callback(update: Update, context: ContextTypes.DEFAULT_TY
         _register_player_chat(user.id, chat.id)
 
 
+def _maybe_update_thread_binding(
+    game_state: GameState | None, thread_id: int
+) -> bool:
+    if game_state is None or thread_id <= 0:
+        return False
+    if getattr(game_state, "thread_id", 0) == thread_id:
+        return False
+    game_state.thread_id = thread_id
+    return True
+
+
 def _store_state(game_state: GameState) -> None:
     with logging_context(chat_id=game_state.chat_id, puzzle_id=game_state.puzzle_id):
         state.active_games[game_state.game_id] = game_state
@@ -1749,6 +1808,8 @@ def _store_state(game_state: GameState) -> None:
                 state.join_codes.pop(code, None)
         for code, target in game_state.join_codes.items():
             state.join_codes[code] = target
+        if game_state.thread_id > 0:
+            state.chat_threads[game_state.chat_id] = game_state.thread_id
         save_state(game_state)
         logger.info("Game state persisted for game %s", game_state.game_id)
 
@@ -1757,7 +1818,14 @@ def _load_state_for_chat(chat_id: int) -> Optional[GameState]:
     with logging_context(chat_id=chat_id):
         game_id = state.chat_to_game.get(chat_id)
         if game_id and game_id in state.active_games:
-            return state.active_games[game_id]
+            cached = state.active_games[game_id]
+            hint_thread = state.chat_threads.get(chat_id, 0)
+            if _maybe_update_thread_binding(cached, hint_thread):
+                state.chat_threads[cached.chat_id] = cached.thread_id
+                save_state(cached)
+            elif getattr(cached, "thread_id", 0) > 0:
+                state.chat_threads[cached.chat_id] = cached.thread_id
+            return cached
         identifiers_to_try: list[str | int] = []
         if game_id is not None:
             identifiers_to_try.append(game_id)
@@ -1785,6 +1853,12 @@ def _load_state_for_chat(chat_id: int) -> Optional[GameState]:
                 state.join_codes.pop(code, None)
         for code, target in restored.join_codes.items():
             state.join_codes[code] = target
+        hint_thread = state.chat_threads.get(restored.chat_id, 0)
+        if _maybe_update_thread_binding(restored, hint_thread):
+            state.chat_threads[restored.chat_id] = restored.thread_id
+            save_state(restored)
+        elif getattr(restored, "thread_id", 0) > 0:
+            state.chat_threads[restored.chat_id] = restored.thread_id
         logger.info("Restored state from disk during command handling")
         return restored
 
@@ -2392,7 +2466,11 @@ async def _game_warning_job(context: CallbackContext) -> None:
         return
     text = "До завершения игры осталось одна минута!"
     try:
-        await context.bot.send_message(chat_id=game_state.chat_id, text=text)
+        await context.bot.send_message(
+            chat_id=game_state.chat_id,
+            text=text,
+            **_thread_kwargs(game_state),
+        )
     except Exception:  # noqa: BLE001
         logger.exception("Failed to send game warning for %s", game_id)
 
@@ -2430,7 +2508,11 @@ async def _turn_warning_job(context: CallbackContext) -> None:
         return
     warning = f"{player.name}, осталось {TURN_WARNING_SECONDS} секунд на ход!"
     try:
-        await context.bot.send_message(chat_id=game_state.chat_id, text=warning)
+        await context.bot.send_message(
+            chat_id=game_state.chat_id,
+            text=warning,
+            **_thread_kwargs(game_state),
+        )
         if player.dm_chat_id and player.dm_chat_id != game_state.chat_id:
             await context.bot.send_message(chat_id=player.dm_chat_id, text=warning)
     except Exception:  # noqa: BLE001
@@ -2550,6 +2632,8 @@ def _generate_composite(
     language: str,
     theme: str,
     components: Sequence[Sequence[WordClue]],
+    *,
+    thread_id: int = 0,
 ) -> tuple[CompositePuzzle, GameState]:
     composite_id = uuid4().hex
     composite_components: list[CompositeComponent] = []
@@ -2596,6 +2680,7 @@ def _generate_composite(
         host_id=chat_id,
         game_id=str(chat_id),
         scoreboard={chat_id: 0},
+        thread_id=thread_id,
     )
     return composite, game_state
 
@@ -2627,7 +2712,7 @@ def _clone_puzzle_for_test(
 
 
 def _generate_puzzle(
-    chat_id: int, language: str, theme: str
+    chat_id: int, language: str, theme: str, thread_id: int = 0
 ) -> tuple[Puzzle | CompositePuzzle, GameState]:
     with logging_context(chat_id=chat_id):
         logger.info(
@@ -2987,7 +3072,11 @@ def _generate_puzzle(
                                 )
                                 try:
                                     composite, game_state = _generate_composite(
-                                        chat_id, language, theme, components
+                                        chat_id,
+                                        language,
+                                        theme,
+                                        components,
+                                        thread_id=thread_id,
                                     )
                                 except FillInGenerationError as composite_error:
                                     logger.debug(
@@ -3022,6 +3111,7 @@ def _generate_puzzle(
                             host_id=chat_id,
                             game_id=str(chat_id),
                             scoreboard={chat_id: 0},
+                            thread_id=thread_id,
                         )
                         _store_state(game_state)
                         logger.info("Generated puzzle ready for delivery")
@@ -3145,6 +3235,7 @@ async def _start_new_private_game(
 async def _start_new_group_game(
     update: Update, context: ContextTypes.DEFAULT_TYPE
 ) -> int:
+    thread_id = _normalise_thread_id(update)
     chat = update.effective_chat
     message = update.effective_message
     user = update.effective_user
@@ -3192,6 +3283,7 @@ async def _start_new_group_game(
         mode="turn_based",
         status="lobby",
         players={},
+        thread_id=thread_id if thread_id > 0 else 0,
     )
     if user and host_id is not None:
         _ensure_player_entry(game_state, user, host_name, dm_chat_id)
@@ -3246,6 +3338,7 @@ async def _process_join_code(
         await context.bot.send_message(
             chat_id=game_state.chat_id,
             text=f"{existing.name} снова с нами!",
+            **_thread_kwargs(game_state),
         )
         return
 
@@ -3261,6 +3354,7 @@ async def _process_join_code(
         await context.bot.send_message(
             chat_id=game_state.chat_id,
             text=f"{player.name} подключился к игре!",
+            **_thread_kwargs(game_state),
         )
         await _update_lobby_message(context, game_state)
         return
@@ -3593,7 +3687,12 @@ async def handle_theme(update: Update, context: ContextTypes.DEFAULT_TYPE) -> in
             state.generating_chats.add(chat.id)
             try:
                 puzzle, generated_state = await loop.run_in_executor(
-                    None, _generate_puzzle, chat.id, language, theme
+                    None,
+                    _generate_puzzle,
+                    chat.id,
+                    language,
+                    theme,
+                    game_state.thread_id if getattr(game_state, "thread_id", 0) else 0,
                 )
             except Exception:  # noqa: BLE001
                 logger.exception(
@@ -3713,7 +3812,12 @@ async def handle_theme(update: Update, context: ContextTypes.DEFAULT_TYPE) -> in
         state.generating_chats.add(chat.id)
         try:
             puzzle, game_state = await loop.run_in_executor(
-                None, _generate_puzzle, chat.id, language, theme
+                None,
+                _generate_puzzle,
+                chat.id,
+                language,
+                theme,
+                state.chat_threads.get(chat.id, 0),
             )
         except Exception:  # noqa: BLE001
             logger.exception("Failed to generate puzzle for chat %s", chat.id)
@@ -3819,7 +3923,12 @@ async def button_theme_handler(update: Update, context: ContextTypes.DEFAULT_TYP
     context.chat_data[GENERATION_TOKEN_KEY] = generation_token
     try:
         puzzle, game_state = await loop.run_in_executor(
-            None, _generate_puzzle, chat.id, language, theme
+            None,
+            _generate_puzzle,
+            chat.id,
+            language,
+            theme,
+            state.chat_threads.get(chat.id, 0),
         )
     except Exception:  # noqa: BLE001
         logger.exception("Failed to generate puzzle for chat %s via button flow", chat.id)
@@ -3933,6 +4042,7 @@ async def join_name_response_handler(
     await context.bot.send_message(
         chat_id=game_state.chat_id,
         text=f"{player.name} присоединился к игре!",
+        **_thread_kwargs(game_state),
     )
     await _update_lobby_message(context, game_state)
 
@@ -4240,6 +4350,7 @@ async def lobby_start_callback_handler(
             await context.bot.send_message(
                 chat_id=game_state.chat_id,
                 text="Не удалось подготовить кроссворд. Попробуйте начать позже.",
+                **_thread_kwargs(game_state),
             )
             return
         refreshed_state = _load_state_by_game_id(game_id)
@@ -4247,6 +4358,7 @@ async def lobby_start_callback_handler(
             await context.bot.send_message(
                 chat_id=game_state.chat_id,
                 text="Кроссворд так и не был подготовлен. Попробуйте ещё раз позже.",
+                **_thread_kwargs(game_state),
             )
             return
         game_state = refreshed_state
@@ -4255,6 +4367,7 @@ async def lobby_start_callback_handler(
             await context.bot.send_message(
                 chat_id=game_state.chat_id,
                 text="Не удалось загрузить кроссворд. Попробуйте позже.",
+                **_thread_kwargs(game_state),
             )
             return
     players_sorted = sorted(
@@ -4282,6 +4395,7 @@ async def lobby_start_callback_handler(
     await context.bot.send_message(
         chat_id=game_state.chat_id,
         text="Игра началась! Ходы идут по очереди.",
+        **_thread_kwargs(game_state),
     )
     await _announce_turn(
         context,
@@ -4348,6 +4462,7 @@ async def _launch_admin_test_game(
         players={admin_id: admin_player, DUMMY_USER_ID: dummy_player},
         turn_order=turn_order,
         turn_index=0,
+        thread_id=base_state.thread_id,
     )
     admin_state.test_mode = True
     admin_state.dummy_user_id = DUMMY_USER_ID
@@ -4373,6 +4488,7 @@ async def _launch_admin_test_game(
         await context.bot.send_message(
             chat_id=base_state.chat_id,
             text="\n".join(intro_lines),
+            **_thread_kwargs(base_state),
         )
     except Exception:  # noqa: BLE001
         logger.exception(
@@ -5619,9 +5735,14 @@ async def completion_callback_handler(update: Update, context: ContextTypes.DEFA
         generation_token = secrets.token_hex(16)
         context.chat_data[GENERATION_TOKEN_KEY] = generation_token
         try:
-            new_puzzle, new_state = await loop.run_in_executor(
-                None, _generate_puzzle, chat.id, language, theme
-            )
+                new_puzzle, new_state = await loop.run_in_executor(
+                    None,
+                    _generate_puzzle,
+                    chat.id,
+                    language,
+                    theme,
+                    state.chat_threads.get(chat.id, 0),
+                )
         except Exception:  # noqa: BLE001
             logger.exception(
                 "Failed to regenerate puzzle for chat %s on same theme", chat.id

--- a/tests/test_multiplayer_flow.py
+++ b/tests/test_multiplayer_flow.py
@@ -47,6 +47,7 @@ def fresh_state():
     state.lobby_messages.clear()
     state.generating_chats.clear()
     state.scheduled_jobs.clear()
+    state.chat_threads.clear()
     yield
     state.active_games.clear()
     state.chat_to_game.clear()
@@ -55,6 +56,7 @@ def fresh_state():
     state.lobby_messages.clear()
     state.generating_chats.clear()
     state.scheduled_jobs.clear()
+    state.chat_threads.clear()
     state.settings = original_settings
 
 
@@ -654,7 +656,15 @@ async def test_turn_based_answer_advances_turn(monkeypatch, tmp_path, fresh_stat
     bot = SimpleNamespace(send_chat_action=AsyncMock(), send_message=AsyncMock())
     context = SimpleNamespace(bot=bot, job_queue=job_queue)
 
+    game_state.thread_id = 321
     await app._announce_turn(context, game_state, puzzle)
+    group_call = next(
+        call
+        for call in bot.send_message.await_args_list
+        if call.kwargs.get("chat_id") == game_state.chat_id
+    )
+    assert group_call.kwargs.get("message_thread_id") == 321
+    bot.send_message.reset_mock()
     assert len(job_queue.submitted) >= 1
     initial_warn_name = game_state.turn_warn_job_id
     initial_timeout_name = game_state.turn_timer_job_id
@@ -703,6 +713,7 @@ async def test_dm_only_game_notifications_send_once(monkeypatch, fresh_state):
 
     assert announce_mock.await_count == 1
     assert announce_mock.await_args.kwargs["chat_id"] == chat_id
+    assert "message_thread_id" not in announce_mock.await_args.kwargs
 
     warning_mock = AsyncMock()
     job_name = "turn-warn-test"

--- a/utils/storage.py
+++ b/utils/storage.py
@@ -86,6 +86,7 @@ class GameState:
 
     chat_id: int
     puzzle_id: str
+    thread_id: int = 0
     filled_cells: Dict[str, str] = field(default_factory=dict)
     solved_slots: set[str] = field(default_factory=set)
     score: int = 0
@@ -127,6 +128,10 @@ class GameState:
         self.game_id = str(self.game_id or self.chat_id)
         self.puzzle_id = str(self.puzzle_id)
         self.chat_id = int(self.chat_id)
+        with suppress(TypeError, ValueError):
+            self.thread_id = int(self.thread_id)
+        if self.thread_id < 0:
+            self.thread_id = 0
         self.score = int(self.score)
         self.mode = str(self.mode or "single")
         self.status = str(self.status or "running")
@@ -246,6 +251,7 @@ class GameState:
             "game_id": self.game_id,
             "chat_id": self.chat_id,
             "puzzle_id": self.puzzle_id,
+            "thread_id": self.thread_id,
             "puzzle_ids": list(self.puzzle_ids) if self.puzzle_ids else None,
             "filled_cells": self.filled_cells,
             "solved_slots": sorted(self.solved_slots),
@@ -358,6 +364,11 @@ class GameState:
         chat_id = int(chat_id_raw)
         game_id = str(game_id_raw) if game_id_raw else str(chat_id)
 
+        thread_raw = payload.get("thread_id")
+        thread_id = int(thread_raw) if thread_raw not in (None, "") else 0
+        if thread_id < 0:
+            thread_id = 0
+
         host_raw = payload.get("host_id")
         host_id = int(host_raw) if host_raw not in (None, "") else None
 
@@ -432,6 +443,7 @@ class GameState:
             chat_id=chat_id,
             host_id=host_id,
             puzzle_id=str(payload["puzzle_id"]),
+            thread_id=thread_id,
             puzzle_ids=puzzle_ids,
             filled_cells=dict(payload.get("filled_cells", {})),
             solved_slots=solved_slots,


### PR DESCRIPTION
## Summary
- track the current Telegram topic by storing a `thread_id` in each `GameState`
- propagate the recorded thread id when generating or resuming multiplayer games and reuse it for lobby/test flows
- ensure group announcements and status updates include the topic id so messages stay in the correct thread
- cover the behaviour with multiplayer flow tests that assert the thread id is passed through

## Testing
- `pytest tests/test_multiplayer_flow.py`


------
https://chatgpt.com/codex/tasks/task_e_68dd93ca0d308326a8f580022354af88