### PR TITLE
Handle stale admin test sessions

### DIFF
--- a/app.py
+++ b/app.py
@@ -3443,6 +3443,17 @@ async def new_game_menu_admin_proxy_handler(
             await query.answer()
         return ConversationHandler.END
     base_state = _load_state_for_chat(chat.id)
+    if base_state is not None:
+        invalid_state = False
+        if base_state.status != "running":
+            invalid_state = True
+        elif not base_state.puzzle_id:
+            invalid_state = True
+        elif load_puzzle(base_state.puzzle_id) is None:
+            invalid_state = True
+        if invalid_state:
+            _cleanup_game_state(base_state)
+            base_state = None
     if base_state is None:
         reply_method = getattr(message, "reply_text", None)
         if not callable(reply_method):
@@ -4452,6 +4463,12 @@ async def admin_test_game_callback_handler(
     base_state = _load_state_for_chat(target_chat_id)
     if base_state is None:
         await query.answer("Нет активной игры для теста.", show_alert=True)
+        return
+    if base_state.status == "finished":
+        await query.answer("Игра завершена, создайте новую.", show_alert=True)
+        return
+    if not base_state.puzzle_id:
+        await query.answer("Кроссворд ещё не готов.", show_alert=True)
         return
     _clear_pending_admin_test(context)
     if base_state.test_mode and base_state.status == "running":

--- a/tests/test_multiplayer_flow.py
+++ b/tests/test_multiplayer_flow.py
@@ -459,6 +459,41 @@ async def test_new_game_menu_admin_proxy_clears_state(monkeypatch, fresh_state):
     assert "new_game_language" not in context.user_data
 
 
+@pytest.mark.anyio
+async def test_admin_proxy_restarts_after_finished_game(monkeypatch, fresh_state):
+    chat = SimpleNamespace(id=1111, type=ChatType.PRIVATE)
+    message = SimpleNamespace(message_thread_id=None, reply_text=AsyncMock())
+    query = SimpleNamespace(
+        data=f"{app.ADMIN_TEST_GAME_CALLBACK_PREFIX}{chat.id}",
+        answer=AsyncMock(),
+        message=message,
+    )
+    update = SimpleNamespace(
+        effective_chat=chat,
+        effective_message=message,
+        callback_query=query,
+    )
+    context = SimpleNamespace(chat_data={}, user_data={}, bot=SimpleNamespace())
+
+    puzzle = _make_turn_puzzle()
+    base_state = _make_turn_state(chat.id, puzzle)
+    base_state.status = "finished"
+    state.active_games[base_state.game_id] = base_state
+    state.chat_to_game[chat.id] = base_state.game_id
+
+    start_group_mock = AsyncMock(return_value=LANGUAGE_STATE)
+    monkeypatch.setattr(app, "_start_new_group_game", start_group_mock)
+
+    result = await new_game_menu_admin_proxy_handler(update, context)
+
+    assert result == LANGUAGE_STATE
+    start_group_mock.assert_awaited_once_with(update, context)
+    assert context.chat_data.get(app.PENDING_ADMIN_TEST_KEY) == chat.id
+    assert base_state.game_id not in state.active_games
+    assert chat.id not in state.chat_to_game
+    query.answer.assert_awaited_once()
+
+
 def test_lobby_keyboard_start_activation(fresh_state):
     puzzle = _make_turn_puzzle()
     game_state = _make_turn_state(-400, puzzle)


### PR DESCRIPTION
## Summary
- treat completed or puzzle-less admin game states as stale before rerunning the test session flow
- prevent launching an admin test game when the base game is finished or has no puzzle
- add a regression test to ensure the admin proxy starts a fresh crossword after a finished session

## Testing
- pytest tests/test_multiplayer_flow.py

------
https://chatgpt.com/codex/tasks/task_e_68dd96cc52fc83269f6f21d6d3082755