### PR TITLE
Fix duplicate first-turn announcement in admin test game

### DIFF
--- a/app.py
+++ b/app.py
@@ -4930,8 +4930,6 @@ async def _launch_admin_test_game(
         f"Игроки: {_user_display_name(admin_user)} и {DUMMY_NAME}.",
     ]
     first_player = admin_state.players.get(admin_state.turn_order[0])
-    if first_player:
-        intro_lines.append(f"Первым ходит {first_player.name}.")
     try:
         await context.bot.send_message(
             chat_id=base_state.chat_id,


### PR DESCRIPTION
## Summary
- avoid repeating the "Первым ходит" line in the admin test game intro message
- update multiplayer flow tests to expect a single first-turn announcement and validate the prefix used

## Testing
- pytest tests/test_multiplayer_flow.py -k admin_test_game -q

------
https://chatgpt.com/codex/tasks/task_e_68deea473c00832690ddddaa2c447709