### PR TITLE
Send dummy success updates only in image captions

### DIFF
--- a/tests/test_multiplayer_flow.py
+++ b/tests/test_multiplayer_flow.py
@@ -1701,15 +1701,12 @@ async def test_dummy_turn_job_success(monkeypatch, tmp_path, fresh_state, caplog
     assert any("Dummy turn" in record.message for record in caplog.records)
     assert job_name not in state.scheduled_jobs
     broadcast_photo_mock.assert_awaited()
-    assert (
-        broadcast_photo_mock.await_args.kwargs.get("caption")
-        == "Верно! A1"
+    expected_caption = (
+        f"Верно! 🤖 Dummy - A1: РИМ (+{app.SCORE_PER_WORD} очков)"
     )
+    assert broadcast_photo_mock.await_args.kwargs.get("caption") == expected_caption
     context.bot.send_photo.assert_awaited()
-    assert (
-        context.bot.send_photo.await_args.kwargs.get("caption")
-        == "Верно! A1"
-    )
+    assert context.bot.send_photo.await_args.kwargs.get("caption") == expected_caption
 
 
 @pytest.mark.anyio
@@ -1791,7 +1788,7 @@ async def test_dummy_turn_job_admin_test_mirrors_primary_chat(
         if call.kwargs.get("chat_id") == game_state.chat_id
     ]
     assert any("отвечает на" in text for text in main_chat_messages)
-    assert any("разгадал" in text for text in main_chat_messages)
+    assert all("разгадал" not in text for text in main_chat_messages)
 
 
 @pytest.mark.anyio


### PR DESCRIPTION
## Summary
- include the dummy player's name, slot and answer in the image caption when it solves a clue and drop the extra text message
- keep broadcasting a fallback text only when the image cannot be delivered
- update the multiplayer tests to reflect the new caption format and single success message

## Testing
- pytest tests/test_multiplayer_flow.py

------
https://chatgpt.com/codex/tasks/task_e_68df7362f6f883269ca1b32284f72261