### PR TITLE
Remove admin lobby button from friends games

### DIFF
--- a/app.py
+++ b/app.py
@@ -1813,20 +1813,6 @@ def _build_lobby_keyboard(game_state: GameState) -> InlineKeyboardMarkup:
         start_callback = f"{LOBBY_WAIT_CALLBACK_PREFIX}{game_state.game_id}"
     start_button = InlineKeyboardButton(text="Старт", callback_data=start_callback)
     rows = [[invite_button, link_button], [start_button]]
-    settings = state.settings
-    if (
-        settings
-        and settings.admin_id is not None
-        and game_state.host_id == settings.admin_id
-    ):
-        rows.append(
-            [
-                InlineKeyboardButton(
-                    "[адм.] Тестовая игра 1×1",
-                    callback_data=f"{ADMIN_TEST_GAME_CALLBACK_PREFIX}{game_state.chat_id}",
-                )
-            ]
-        )
     return InlineKeyboardMarkup(rows)
 
 

--- a/tests/test_multiplayer_flow.py
+++ b/tests/test_multiplayer_flow.py
@@ -769,6 +769,26 @@ def test_lobby_keyboard_start_activation(fresh_state):
     assert start_data.startswith(LOBBY_START_CALLBACK_PREFIX)
 
 
+def test_lobby_keyboard_excludes_admin_button_after_entry(fresh_state):
+    puzzle = _make_turn_puzzle()
+    game_state = _make_turn_state(-401, puzzle)
+    game_state.status = "lobby"
+    state.settings = SimpleNamespace(admin_id=game_state.host_id)
+
+    keyboard = app._build_lobby_keyboard(game_state)
+
+    admin_callbacks = [
+        button.callback_data
+        for row in keyboard.inline_keyboard
+        for button in row
+        if button.callback_data
+    ]
+    assert all(
+        not callback.startswith(app.ADMIN_TEST_GAME_CALLBACK_PREFIX)
+        for callback in admin_callbacks
+    )
+
+
 @pytest.mark.anyio
 async def test_join_code_limits_players(monkeypatch, fresh_state):
     puzzle = _make_turn_puzzle()


### PR DESCRIPTION
## Summary
- remove the admin-only test-game button from the friends lobby keyboard so it only appears in the initial menu
- add coverage to confirm the lobby keyboard omits the admin button for friends games while existing menu behaviour remains intact

## Testing
- pytest tests/test_multiplayer_flow.py

------
https://chatgpt.com/codex/tasks/task_e_68dfb5ad5e3c8326ab160899b7741f19