### PR TITLE
Fix lobby contact handler keyboard initialization

### DIFF
--- a/app.py
+++ b/app.py
@@ -4806,16 +4806,16 @@ async def lobby_contact_handler(
         return
     user_store = _ensure_user_store_for(context, user.id)
     pending = user_store.get("pending_invite")
+    expected_request_id: int | None = None
+    game_id: str | None = None
+    code_hint: str | None = None
     if isinstance(pending, dict):
         expected_request_id = pending.get("request_id")
         game_id = pending.get("game_id")
         code_hint = pending.get("code")
     else:
         pending = None
-        expected_request_id = None
-        game_id = None
-        code_hint = None
-        reply_keyboard = (
+    reply_keyboard = (
         _build_lobby_invite_keyboard(expected_request_id)
         if expected_request_id is not None
         else None


### PR DESCRIPTION
## Summary
- ensure the lobby contact handler always builds the invite keyboard after loading pending invite metadata
- keep safe defaults for invite metadata and cover the scenario with a regression test

## Testing
- pytest tests/test_multiplayer_flow.py::test_lobby_contact_handler_uses_reply_keyboard -q

------
https://chatgpt.com/codex/tasks/task_e_68dff3fc0a5c83268f1a4ae31d7bb161