### PR TITLE
Ensure group lobby receives broadcasts without host DM

### DIFF
--- a/app.py
+++ b/app.py
@@ -776,7 +776,16 @@ def _iter_player_dm_chats(game_state: GameState) -> list[tuple[int | None, int]]
             continue
         seen.add(player.dm_chat_id)
         chats.append((player.user_id, player.dm_chat_id))
+    include_group_chat = False
+    host_id = game_state.host_id
+    if host_id is not None:
+        host_player = game_state.players.get(host_id)
+        if host_player is None or host_player.dm_chat_id is None:
+            include_group_chat = True
     if not chats:
+        include_group_chat = True
+    if include_group_chat and game_state.chat_id not in seen:
+        seen.add(game_state.chat_id)
         chats.append((None, game_state.chat_id))
     return chats
 


### PR DESCRIPTION
## Summary
- ensure `_iter_player_dm_chats` includes the lobby chat whenever the host has no DM mapping while still deduplicating player chats
- add regression tests covering the lobby inclusion and its removal once the host DM is known

## Testing
- pytest tests/test_multiplayer_flow.py::test_iter_player_dm_chats_includes_group_when_host_missing_dm tests/test_multiplayer_flow.py::test_iter_player_dm_chats_skips_group_once_host_has_dm

------
https://chatgpt.com/codex/tasks/task_e_68dff8a79f2c832693727cf21a5eabb7