### PR TITLE
Fix leaderboard formatting for HTML parse mode

### DIFF
--- a/app.py
+++ b/app.py
@@ -1647,7 +1647,7 @@ def _format_leaderboard(game_state: GameState) -> str:
         lines.append(
             f"{index}. <b>{display_name}</b> — {score} очков • ✅ {solved} • 💡 {hints}"
         )
-    return "<br/>".join(lines)
+    return "\n".join(lines)
 
 
 async def _finish_game(

--- a/tests/test_multiplayer_flow.py
+++ b/tests/test_multiplayer_flow.py
@@ -1729,7 +1729,7 @@ def test_format_leaderboard_orders_players(fresh_state):
 
     text = app._format_leaderboard(game_state)
 
-    lines = text.split("<br/>")
+    lines = text.splitlines()
     assert lines[0].startswith("1. <b>Игрок 3")
     assert lines[1].startswith("2. <b>Игрок 2")
     assert "💡 2" in lines[0]


### PR DESCRIPTION
## Summary
- replace the `<br/>` joiner in `_format_leaderboard` with newline characters while keeping HTML escaping intact
- update the leaderboard ordering test to assert against newline-separated output

## Testing
- pytest tests/test_multiplayer_flow.py::test_format_leaderboard_orders_players
- pytest tests/test_multiplayer_flow.py::test_dummy_turn_job_success

------
https://chatgpt.com/codex/tasks/task_e_68e09f412ab483268df80d091ea0712d