### PR TITLE
Update inline answer UX to rely on chat responses

### DIFF
--- a/tests/test_inline_answers.py
+++ b/tests/test_inline_answers.py
@@ -11,6 +11,8 @@ from telegram.constants import ChatType
 from telegram.ext import ConversationHandler
 
 from app import (
+    ANSWER_FORMAT_EXAMPLES,
+    HOW_TO_ANSWER_LABEL,
     GENERATION_NOTICE_KEY,
     GENERATION_TOKEN_KEY,
     LOBBY_INVITE_BUTTON_TEXT,
@@ -46,6 +48,10 @@ from utils.storage import GameState
         ("А1:шпиц", ("A1", "шпиц")),
         ("А1:  шпиц", ("A1", "шпиц")),
         ("1 шпиц", ("1", "шпиц")),
+        ("1 - шпиц", ("1", "шпиц")),
+        ("1:шпиц", ("1", "шпиц")),
+        ("1- шпиц", ("1", "шпиц")),
+        ("1 : шпиц", ("1", "шпиц")),
         ("  15   ответ  ", ("15", "ответ")),
     ],
 )
@@ -116,7 +122,10 @@ async def test_inline_handler_replies_when_parse_fails_with_active_game():
     message.reply_text.assert_awaited_once()
     reply_call = message.reply_text.await_args
     assert reply_call.args
-    assert "A1 - слово" in reply_call.args[0]
+    reply_text = reply_call.args[0]
+    assert HOW_TO_ANSWER_LABEL in reply_text
+    for example in ("A1 париж", "A1 - париж", "A1: париж", "1 париж"):
+        assert example in reply_text or ANSWER_FORMAT_EXAMPLES in reply_text
 
 
 @pytest.mark.anyio

--- a/tests/test_multiplayer_flow.py
+++ b/tests/test_multiplayer_flow.py
@@ -11,6 +11,7 @@ from telegram.ext import ConversationHandler
 
 import app
 from app import (
+    HOW_TO_ANSWER_LABEL,
     HINT_PENALTY,
     LANGUAGE_STATE,
     LOBBY_START_CALLBACK_PREFIX,
@@ -1521,7 +1522,9 @@ async def test_dm_only_game_notifications_send_once(monkeypatch, fresh_state):
     announce_kwargs = second_call.kwargs
     assert announce_kwargs["chat_id"] == chat_id
     assert "message_thread_id" not in announce_kwargs
-    assert "/answer" in announce_kwargs.get("text", "")
+    turn_text = announce_kwargs.get("text", "")
+    assert HOW_TO_ANSWER_LABEL in turn_text
+    assert "прямо в чат" in turn_text
     assert announce_kwargs.get("reply_markup") is None
 
     warning_mock = AsyncMock()


### PR DESCRIPTION
## Summary
- remove the legacy /answer command handler and rely on inline text submissions with clearer guidance
- add shared answer format hints that reference the "Как отвечать?" helper and reuse them in turn announcements and puzzle delivery
- expand inline answer parsing coverage and multiplayer expectations to accept numeric prefixes and the new error text

## Testing
- `pytest tests/test_inline_answers.py tests/test_multiplayer_flow.py`


------
https://chatgpt.com/codex/tasks/task_e_68e0b35f462c8326a8e2aa8a47a49ee9