### PR TITLE
Remove /answer command and refresh inline answer UX

### DIFF
--- a/app.py
+++ b/app.py
@@ -625,8 +625,8 @@ MENU_CALLBACK_PREFIX = f"{COMPLETION_CALLBACK_PREFIX}menu:"
 
 ANSWER_HELP_CALLBACK_DATA = "answer_help"
 ANSWER_HELP_ALERT_TEXT = (
-    "Отправляйте ответы прямо в чат в формате «A1 - ответ». "
-    "Если удобнее, можно пользоваться и командой /answer."
+    "Отправляйте ответы прямо в чат. Подходят варианты: «A1 париж», "
+    "«A1 - париж», «A1: париж», «1 париж»."
 )
 ANSWER_HELP_PROMPT = "Как отвечать? Нажмите кнопку ниже."
 
@@ -1541,7 +1541,8 @@ async def _announce_turn(
         parts.append(prefix)
     parts.append(
         "Ход игрока "
-        f"{player.name}. Ответьте командой /answer <слот> <слово> или запросите подсказку через /hint <слот>."
+        f"{player.name}. Отправьте ответ прямо в чат (например: «A1 париж»). "
+        "Нужен формат — воспользуйтесь подсказкой «Как отвечать?» или запросите подсказку через /hint <слот>."
     )
     text = "\n".join(parts)
     try:
@@ -6114,24 +6115,6 @@ async def admin_answer_request_handler(update: Update, context: ContextTypes.DEF
 
 
 @command_entrypoint()
-async def answer_command(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
-    _normalise_thread_id(update)
-    chat = update.effective_chat
-    message = update.effective_message
-    if chat is None or message is None:
-        return
-    if not await _reject_group_chat(update):
-        return
-    if not context.args or len(context.args) < 2:
-        await message.reply_text("Использование: /answer <слот> <слово>")
-        return
-
-    slot_id = context.args[0]
-    raw_answer = " ".join(context.args[1:])
-    await _handle_answer_submission(context, chat, message, slot_id, raw_answer)
-
-
-@command_entrypoint()
 async def inline_answer_handler(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
     _normalise_thread_id(update)
     if not await _reject_group_chat(update):
@@ -6252,7 +6235,8 @@ async def inline_answer_handler(update: Update, context: ContextTypes.DEFAULT_TY
                 },
             )
             await message.reply_text(
-                "Не удалось распознать ответ. Используйте формат «A1 - слово»."
+                "Не удалось распознать ответ. Нажмите «Как отвечать?» или "
+                "отправьте в формате «A1 париж», «A1 - париж», «A1: париж», «1 париж»."
             )
         else:
             logger.debug(
@@ -6834,7 +6818,6 @@ def configure_telegram_handlers(telegram_application: Application) -> None:
     )
     telegram_application.add_handler(CommandHandler("clues", send_clues))
     telegram_application.add_handler(CommandHandler("state", send_state_image))
-    telegram_application.add_handler(CommandHandler("answer", answer_command))
     telegram_application.add_handler(CommandHandler(["hint", "open"], hint_command))
     telegram_application.add_handler(CommandHandler("solve", solve_command))
     telegram_application.add_handler(CommandHandler("finish", finish_command))

--- a/tests/test_inline_answers.py
+++ b/tests/test_inline_answers.py
@@ -46,6 +46,9 @@ from utils.storage import GameState
         ("А1:шпиц", ("A1", "шпиц")),
         ("А1:  шпиц", ("A1", "шпиц")),
         ("1 шпиц", ("1", "шпиц")),
+        ("1 - шпиц", ("1", "шпиц")),
+        ("1:шпиц", ("1", "шпиц")),
+        ("1: шпиц", ("1", "шпиц")),
         ("  15   ответ  ", ("15", "ответ")),
     ],
 )
@@ -116,7 +119,7 @@ async def test_inline_handler_replies_when_parse_fails_with_active_game():
     message.reply_text.assert_awaited_once()
     reply_call = message.reply_text.await_args
     assert reply_call.args
-    assert "A1 - слово" in reply_call.args[0]
+    assert "Как отвечать?" in reply_call.args[0]
 
 
 @pytest.mark.anyio

--- a/tests/test_multiplayer_flow.py
+++ b/tests/test_multiplayer_flow.py
@@ -1534,7 +1534,10 @@ async def test_dm_only_game_notifications_send_once(monkeypatch, fresh_state):
     announce_kwargs = second_call.kwargs
     assert announce_kwargs["chat_id"] == chat_id
     assert "message_thread_id" not in announce_kwargs
-    assert "/answer" in announce_kwargs.get("text", "")
+    text = announce_kwargs.get("text", "")
+    assert "Отправьте ответ прямо в чат" in text
+    assert "Как отвечать?" in text
+    assert "/answer" not in text
     assert announce_kwargs.get("reply_markup") is None
 
     warning_mock = AsyncMock()


### PR DESCRIPTION
## Summary
- remove the /answer command and rely on inline submissions with updated help messaging
- refresh the turn announcement and inline error prompts to highlight the "Как отвечать?" guidance and supported formats
- extend inline answer and multiplayer flow tests to cover the new formats and messaging

## Testing
- pytest tests/test_inline_answers.py tests/test_multiplayer_flow.py

------
https://chatgpt.com/codex/tasks/task_e_68e0c1c06b588326a7f6929b61cd43a6