### PR TITLE
Update answer instructions handling

### DIFF
--- a/tests/test_clue_formatting.py
+++ b/tests/test_clue_formatting.py
@@ -2,7 +2,7 @@
 
 from utils.crossword import Cell, Direction, Puzzle, Slot, SlotRef
 
-from app import ANSWER_HELP_PROMPT, _format_clue_section, _format_clues_message
+from app import _format_clue_section, _format_clues_message
 
 
 def _build_puzzle_with_slots() -> Puzzle:
@@ -62,7 +62,4 @@ def test_format_clues_message_without_length_hint() -> None:
     message = _format_clues_message(puzzle)
 
     assert "(2)" not in message
-    assert message == (
-        "Across:\nA1: Across clue\n\nDown:\nD2: Down clue\n\n"
-        f"{ANSWER_HELP_PROMPT}"
-    )
+    assert message == "Across:\nA1: Across clue\n\nDown:\nD2: Down clue"

--- a/tests/test_inline_answers.py
+++ b/tests/test_inline_answers.py
@@ -119,7 +119,7 @@ async def test_inline_handler_replies_when_parse_fails_with_active_game():
     message.reply_text.assert_awaited_once()
     reply_call = message.reply_text.await_args
     assert reply_call.args
-    assert "Как отвечать?" in reply_call.args[0]
+    assert app.ANSWER_INSTRUCTIONS_TEXT in reply_call.args[0]
 
 
 @pytest.mark.anyio


### PR DESCRIPTION
## Summary
- replace the inline help button with a static ANSWER_INSTRUCTIONS_TEXT constant and announce the format after every clue delivery
- update turn announcements and inline answer fallback text to reference the new answer format
- adjust clue-related tests to expect a separate instruction message and remove the old help callback

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68e0fc0fa4fc8326b22c0ea25629ec85