### PR TITLE
Update admin test announcements for admin flow

### DIFF
--- a/tests/test_multiplayer_flow.py
+++ b/tests/test_multiplayer_flow.py
@@ -708,12 +708,12 @@ async def test_handle_theme_admin_test_launch(monkeypatch, fresh_state):
 
     assert result == ConversationHandler.END
     run_generate_mock.assert_awaited_once()
-    assert message.reply_text.await_count == 1
-    assert "Подбираю" in message.reply_text.await_args_list[0].args[0]
+    assert message.reply_text.await_count == 2
+    wait_text, start_text = [call.args[0] for call in message.reply_text.await_args_list]
+    assert "Готовлю тестовый кроссворд" in wait_text
+    assert "Тестовая игра 1×1" in start_text
     send_calls = context.bot.send_message.await_args_list
-    assert len(send_calls) == 1
-    assert "Тестовая игра 1×1" in send_calls[0].kwargs["text"]
-    assert send_calls[0].kwargs["chat_id"] == chat_id
+    assert len(send_calls) == 0
     assert app.PENDING_ADMIN_TEST_KEY not in context.chat_data
     announce_mock.assert_awaited()
     assert stored_states, "Admin state should be stored"


### PR DESCRIPTION
## Summary
- revise the admin theme handler messages to announce the 1×1 test game before puzzle generation
- add switches to skip duplicate start and clue announcements when launching admin test games from the theme flow
- update the multiplayer flow test to expect the new messaging behaviour

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e102c539548326ba91041e32bba840