### PR TITLE
Fix admin test launch message order

### DIFF
--- a/app.py
+++ b/app.py
@@ -4491,15 +4491,15 @@ async def handle_theme(update: Update, context: ContextTypes.DEFAULT_TYPE) -> in
         if is_admin_flow:
             state.lobby_generation_tasks.pop(game_state.game_id, None)
             await message.reply_text(
-                "[адм.] Готовлю тестовый кроссворд, это может занять немного времени.",
-            )
-            await message.reply_text(
                 "\n".join(
                     [
                         "[адм.] Тестовая игра 1×1 запущена!",
                         f"Игроки: {_user_display_name(user)} и {DUMMY_NAME}.",
                     ]
                 )
+            )
+            await message.reply_text(
+                "[адм.] Готовлю тестовый кроссворд, это может занять немного времени.",
             )
             loop = asyncio.get_running_loop()
             puzzle: Puzzle | CompositePuzzle | None = None

--- a/tests/test_multiplayer_flow.py
+++ b/tests/test_multiplayer_flow.py
@@ -709,9 +709,9 @@ async def test_handle_theme_admin_test_launch(monkeypatch, fresh_state):
     assert result == ConversationHandler.END
     run_generate_mock.assert_awaited_once()
     assert message.reply_text.await_count == 2
-    wait_text, start_text = [call.args[0] for call in message.reply_text.await_args_list]
-    assert "Готовлю тестовый кроссворд" in wait_text
+    start_text, wait_text = [call.args[0] for call in message.reply_text.await_args_list]
     assert "Тестовая игра 1×1" in start_text
+    assert "Готовлю тестовый кроссворд" in wait_text
     send_calls = context.bot.send_message.await_args_list
     assert len(send_calls) == 0
     assert app.PENDING_ADMIN_TEST_KEY not in context.chat_data


### PR DESCRIPTION
## Summary
- send the admin test launch confirmation before the generation notice to match the expected chat order
- update the admin test flow unit test to reflect the new ordering

## Testing
- pytest tests/test_multiplayer_flow.py::test_handle_theme_admin_test_launch

------
https://chatgpt.com/codex/tasks/task_e_68e10678b6988326803ead249343bbcb