### PR TITLE
Update hint messaging and turn announcements

### DIFF
--- a/app.py
+++ b/app.py
@@ -625,7 +625,9 @@ NEW_PUZZLE_CALLBACK_PREFIX = f"{COMPLETION_CALLBACK_PREFIX}new:"
 MENU_CALLBACK_PREFIX = f"{COMPLETION_CALLBACK_PREFIX}menu:"
 
 ANSWER_INSTRUCTIONS_TEXT = (
-    'Отвечайте в формате:  "А1 - париж",   "А1 париж", или просто "1 париж".'
+    'Отвечайте в формате: "А1 - париж", "А1 париж" или просто "1 париж". '
+    'Подсказку можно запросить сообщением "?A1" (или с другим слотом). '
+    'Имейте в виду: подсказки уменьшают итоговый счёт.'
 )
 
 NEW_GAME_MENU_CALLBACK_PREFIX = "new_game_mode:"
@@ -1542,11 +1544,7 @@ async def _announce_turn(
     if prefix:
         parts.append(prefix)
     player_name = html.escape(player.name if player.name else "игрок")
-    parts.append(
-        "Ход игрока "
-        f"{player_name}. Отправьте ответ прямо в чат — например: «A1 париж», "
-        "«A1 - париж» или «1 париж». Для подсказки используйте /hint <слот>."
-    )
+    parts.append(f"Ход игрока {player_name}.")
     text = "\n".join(parts)
     try:
         broadcast = await _broadcast_to_players(
@@ -3196,7 +3194,7 @@ async def _reminder_job(context: CallbackContext) -> None:
         try:
             await context.bot.send_message(
                 chat_id=chat_id,
-                text="Не забывайте про /hint, если нужна подсказка!",
+                text="Нужна помощь? Отправьте «?A1» (или другой слот) — но учтите, что подсказки снижают очки!",
             )
         except Exception:  # noqa: BLE001
             logger.exception("Failed to deliver reminder message to chat %s", chat_id)

--- a/tests/test_multiplayer_flow.py
+++ b/tests/test_multiplayer_flow.py
@@ -1435,7 +1435,8 @@ async def test_correct_answer_sends_clues_before_turn(monkeypatch, tmp_path, fre
     assert first_call.args[2] == updated_clues
     assert first_call.kwargs.get("parse_mode") == constants.ParseMode.HTML
     assert second_call.args[2] == ANSWER_INSTRUCTIONS_TEXT
-    assert "Ход игрока" in third_call.args[2]
+    expected_turn_text = "Ход игрока Игрок 2."
+    assert third_call.args[2] == expected_turn_text
 
     send_calls = bot.send_message.await_args_list
     assert len(send_calls) >= 3
@@ -1445,7 +1446,7 @@ async def test_correct_answer_sends_clues_before_turn(monkeypatch, tmp_path, fre
     assert first_kwargs.get("reply_markup") is None
     assert send_calls[1].kwargs.get("text") == ANSWER_INSTRUCTIONS_TEXT
     assert send_calls[1].kwargs.get("parse_mode") is None
-    assert "Ход игрока" in send_calls[2].kwargs.get("text", "")
+    assert send_calls[2].kwargs.get("text", "") == expected_turn_text
 
     assert stored_states, "Game state should be stored after correct answer"
 
@@ -1551,8 +1552,8 @@ async def test_dm_only_game_notifications_send_once(monkeypatch, fresh_state):
     assert announce_kwargs["chat_id"] == chat_id
     assert "message_thread_id" not in announce_kwargs
     text = announce_kwargs.get("text", "")
-    assert "Отправьте ответ прямо в чат" in text
-    assert "A1 - париж" in text
+    expected_turn_text = "Ход игрока Игрок 1."
+    assert text == expected_turn_text
     assert "/answer" not in text
     assert announce_kwargs.get("reply_markup") is None
 


### PR DESCRIPTION
## Summary
- refresh the inline answer instructions to mention the ?A1 hint syntax and reduced score
- simplify turn announcement copy and update reminder text to the new hint guidance
- align multiplayer flow tests with the revised strings

## Testing
- pytest tests/test_inline_answers.py tests/test_multiplayer_flow.py

------
https://chatgpt.com/codex/tasks/task_e_68e10ed09e0483268b445a99276897aa