### PR TITLE
Fix lobby callback handler registration syntax

### DIFF
--- a/app.py
+++ b/app.py
@@ -7361,7 +7361,7 @@ def configure_telegram_handlers(telegram_application: Application) -> None:
     telegram_application.add_handler(
         CallbackQueryHandler(
             lobby_start_callback_handler,
-            pattern = rf"^(?:{re.escape(LOBBY_START_CALLBACK_PREFIX)}|{re.escape(LOBBY_WAIT_CALLBACK_PREFIX)})"
+            pattern=rf"^(?:{re.escape(LOBBY_START_CALLBACK_PREFIX)}|{re.escape(LOBBY_WAIT_CALLBACK_PREFIX)})",
             block=False,
         ),
         group=-2,


### PR DESCRIPTION
## Summary
- correct the lobby callback handler registration to use valid keyword argument syntax

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e6519025348326a6b882ad65fbb4cd